### PR TITLE
Add new host flag and fix project flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,15 @@ firestore -p demo-flux collection query --sort firstName --direction desc -f fir
 
 ## Firestore Emulator
 
-To use this tool with the Firestore Emulator you must set the `FIRESTORE_EMULATOR_HOST` environment variable to the appropriate value. For example:
+To use this tool with the Firestore Emulator, you can either set the `FIRESTORE_EMULATOR_HOST` environment variable or use the `--host` flag:
 
-```
+```bash
+# Using environment variable
 export FIRESTORE_EMULATOR_HOST=localhost:9090
+firestore document get /my-collection/my-document
+
+# Using --host flag
+firestore --host localhost:9090 document get /my-collection/my-document
 ```
+
+The `--host` flag will override the environment variable if both are set.

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -19,8 +19,7 @@ var rootCmd = &cobra.Command{
 	Aliases: []string{"fs"},
 	Short:   "perform actions on firestore",
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-		flagValue, _ := cmd.PersistentFlags().GetString("project")
-		if flagValue == "" {
+		if projectId == "" {
 			envValue := os.Getenv("PROJECT_ID")
 			if envValue == "" {
 				return fmt.Errorf("missing PROJECT_ID: --project (-p) [PROJECT_ID]")

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -28,6 +28,11 @@ var rootCmd = &cobra.Command{
 			projectId = envValue
 		}
 
+		// Set Firestore emulator host if --host flag is provided
+		if host != "" {
+			os.Setenv("FIRESTORE_EMULATOR_HOST", host)
+		}
+
 		ctx := cmd.Context()
 		client, err := firestore.NewClient(ctx, projectId)
 		if err != nil {
@@ -49,9 +54,11 @@ func Execute() {
 }
 
 var projectId string
+var host string
 
 func init() {
 	rootCmd.PersistentFlags().StringVarP(&projectId, "project", "p", "", "Google Cloud Project")
+	rootCmd.PersistentFlags().StringVar(&host, "host", "", "Firestore host (e.g., localhost:8080 for emulator)")
 	rootCmd.AddCommand(document.NewDocumentCmd())
 	rootCmd.AddCommand(collection.NewCollectionCmd())
 }

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -15,9 +15,10 @@ import (
 
 // rootCmd represents the base command when called without any subcommands.
 var rootCmd = &cobra.Command{
-	Use:     "firestore",
-	Aliases: []string{"fs"},
-	Short:   "perform actions on firestore",
+	Use:          "firestore",
+	Aliases:      []string{"fs"},
+	Short:        "perform actions on firestore",
+	SilenceUsage: true,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		if projectId == "" {
 			envValue := os.Getenv("PROJECT_ID")


### PR DESCRIPTION
This PR adds a new `--host` flag to allow setting the firestore host. It also fixes the `-p` which was not correctly updating the project id. Finally, we suppress usage docs on firestore client errors to make the output clearer. Usage will only show when an invalid or incomplete command has been used.
