### PR TITLE
feat: TUI enhancements (path jump, full height columns)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ firestore browse users/abc123/preferences
 - `j` / `k` (or `Up`/`Down`): Move selection up and down
 - `l` / `h` (or `Enter`/`Left`): Navigate forward (into a collection/doc) or backward
 - `Ctrl+d` / `Ctrl+u` (or `PgDn`/`PgUp`): Scroll document content or long lists
+- `Ctrl+g`: Open path input to jump to a specific path
 - `g` / `G`: Jump to the top or bottom of the list
 - `r`: Refresh the current column
 - `q`: Quit the browser

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 )
 
 require (
+	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc // indirect
 	github.com/charmbracelet/x/ansi v0.10.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ cloud.google.com/go/longrunning v0.5.0 h1:DK8BH0+hS+DIvc9a2TPnteUievsTCH4ORMAASS
 cloud.google.com/go/longrunning v0.5.0/go.mod h1:0JNuqRShmscVAhIACGtskSAWtqtOoPkwP0YF1oVEchc=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
+github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
+github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=

--- a/pkg/cmd/browse/model.go
+++ b/pkg/cmd/browse/model.go
@@ -4,8 +4,17 @@ import (
 	"context"
 
 	"cloud.google.com/go/firestore"
+	"github.com/charmbracelet/bubbles/textinput"
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
+)
+
+// InputMode indicates whether the user is typing a path
+type InputMode int
+
+const (
+	ModeNormal InputMode = iota
+	ModePathInput
 )
 
 // Model represents the entire TUI state
@@ -19,6 +28,10 @@ type Model struct {
 	height       int      // Terminal height
 	loading      bool
 	err          error
+
+	// Path input
+	mode      InputMode
+	textInput textinput.Model
 }
 
 // Column represents a single column in the Miller columns layout
@@ -89,7 +102,10 @@ func (m Model) Init() tea.Cmd {
 
 	// Fetch initial data for first column
 	if len(m.columns) > 0 {
-		return fetchColumnData(m.client, m.columns[0].path, m.columns[0].isDoc, 0)
+		return tea.Batch(
+			textinput.Blink,
+			fetchColumnData(m.client, m.columns[0].path, m.columns[0].isDoc, 0),
+		)
 	}
-	return nil
+	return textinput.Blink
 }

--- a/pkg/cmd/browse/root.go
+++ b/pkg/cmd/browse/root.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"cloud.google.com/go/firestore"
+	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/gugahoi/firestore/pkg/cmd/keys"
 	"github.com/spf13/cobra"
@@ -44,6 +45,12 @@ Examples:
 				isDoc = len(segments)%2 == 0
 			}
 
+			// Initialize text input
+			ti := textinput.New()
+			ti.Placeholder = "Collection/Document/Collection..."
+			ti.CharLimit = 150
+			ti.Width = 50
+
 			// Initialize model
 			m := Model{
 				client:       client,
@@ -55,6 +62,8 @@ Examples:
 				height:       0,
 				loading:      true,
 				err:          nil,
+				textInput:    ti,
+				mode:         ModeNormal,
 			}
 
 			// Run TUI

--- a/pkg/cmd/browse/styles.go
+++ b/pkg/cmd/browse/styles.go
@@ -91,4 +91,10 @@ var (
 	treeTypeStyle = lipgloss.NewStyle().
 			Foreground(lipgloss.Color("245")). // Light gray for object/array type indicators
 			Italic(true)
+
+	// Input dialog style
+	inputDialogStyle = lipgloss.NewStyle().
+				Border(lipgloss.RoundedBorder()).
+				BorderForeground(colorCyan).
+				Padding(1, 2)
 )

--- a/pkg/cmd/browse/update.go
+++ b/pkg/cmd/browse/update.go
@@ -1,18 +1,70 @@
 package browse
 
 import (
+	"strings"
+
+	"github.com/charmbracelet/bubbles/textinput"
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
 )
 
 // Update handles all messages and updates the model
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	var cmd tea.Cmd
+
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
 		logDebug("KeyMsg received: %s", msg.String())
+
+		// Handle input mode
+		if m.mode == ModePathInput {
+			switch msg.String() {
+			case "enter":
+				// Browse to new path
+				path := strings.Trim(m.textInput.Value(), "/")
+
+				// Determine if it is a doc or collection
+				// A simple heuristic: even segments = doc, odd = collection
+				// Root (empty string) is handled as collection list
+				isDoc := false
+				if path != "" {
+					segments := strings.Split(path, "/")
+					isDoc = len(segments)%2 == 0
+				}
+
+				// Reset columns
+				m.columns = []Column{{
+					path:         path,
+					isDoc:        isDoc,
+					scrollOffset: 0,
+				}}
+				m.activeColumn = 0
+				m.mode = ModeNormal
+				m.textInput.Blur()
+				m.textInput.Reset()
+				m.loading = true
+				return m, fetchColumnData(m.client, path, isDoc, 0)
+			case "esc":
+				m.mode = ModeNormal
+				m.textInput.Blur()
+				m.textInput.Reset()
+				return m, nil
+			}
+			m.textInput, cmd = m.textInput.Update(msg)
+			return m, cmd
+		}
+
+		// Handle normal mode global keys
+		if msg.String() == "ctrl+g" {
+			m.mode = ModePathInput
+			m.textInput.Focus()
+			return m, textinput.Blink
+		}
+
 		return m.handleKeyPress(msg)
 
 	case tea.WindowSizeMsg:
+
 		logDebug("WindowSizeMsg received: width=%d, height=%d", msg.Width, msg.Height)
 		m.width = msg.Width
 		m.height = msg.Height

--- a/pkg/cmd/browse/view.go
+++ b/pkg/cmd/browse/view.go
@@ -54,7 +54,7 @@ func (m Model) View() string {
 
 	// Footer
 	footer := footerStyle.Render(
-		"j/k: Up/Down  h/l: Back/Forward  g/G: Top/Bottom  Ctrl+d/u: Scroll  r: Refresh  q: Quit",
+		"j/k: Up/Down  h/l: Back/Forward  g/G: Top/Bottom  Ctrl+d/u: Scroll  Ctrl+g: Go to  r: Refresh  q: Quit",
 	)
 
 	// Error message
@@ -85,6 +85,47 @@ func (m Model) View() string {
 		footer,
 	)
 	logDebug("View: JoinVertical successful, contentLen=%d", len(content))
+
+	// Overlay input dialog if in input mode
+	if m.mode == ModePathInput {
+		// Create dialog content
+		dialogContent := lipgloss.JoinVertical(
+			lipgloss.Center,
+			"Enter Firestore Path:",
+			m.textInput.View(),
+		)
+		dialog := inputDialogStyle.Render(dialogContent)
+
+		// Center dialog over existing content
+		// For simplicity in Bubble Tea without advanced layering, we can just replace the content
+		// or use lipgloss.Place to overlay if we had a full screen canvas,
+		// but standard string joining doesn't do z-index.
+		// However, lipgloss.Place can position a string within a given dimension.
+		// We can try to overlay it on top of the 'content' string if we treat 'content' as the background?
+		// But lipgloss.Place works on a whitespace background.
+		// A simpler way for a TUI modal:
+		// Just render the dialog in the middle of the screen size, replacing the middle part?
+		// Or render it OVER the content using lipgloss.Place.
+
+		// Let's use lipgloss.Place to center the dialog in the full terminal size
+		return lipgloss.Place(
+			m.width,
+			m.height,
+			lipgloss.Center,
+			lipgloss.Center,
+			dialog,
+			lipgloss.WithWhitespaceChars(" "),
+			lipgloss.WithWhitespaceForeground(colorGray), // Dim background? No, this replaces background
+		)
+		// Wait, this REPLACES the entire view with the placed dialog on a blank background.
+		// To show the underlying content dimmed, we'd need to manually composite.
+		// For now, replacing the view with the dialog is acceptable for a modal,
+		// but ideally we want to see the background.
+		// Given the constraints, let's just return the dialog centered on a blank screen for now to ensure it works.
+		// Or better: render the main view, then if we could overlay...
+		// But string overlay is hard.
+		// Let's just return the dialog centered. It's a "modal" mode.
+	}
 
 	return content
 }

--- a/pkg/cmd/browse/view.go
+++ b/pkg/cmd/browse/view.go
@@ -242,10 +242,10 @@ func (m Model) renderColumn(col Column, width int, isActive bool) string {
 	// - header (1)
 	// - path (1)
 	// - footer (1)
-	// - some margin (4)
-	// Total overhead = 7
+	// - some margin (1)
+	// Total overhead = 4
 	// We also need to account for the border (top + bottom = 2)
-	height := m.height - 7 - 2
+	height := m.height - 4 - 2
 	if height < 1 {
 		height = 10 // Minimum height
 	}
@@ -459,12 +459,11 @@ func (m Model) renderColumn(col Column, width int, isActive bool) string {
 		}
 	}()
 
-	// Don't set explicit height on the style - let it use the content height
-	// Setting Height() would add padding to reach that height, making content longer
+	// Always set explicit height on the style to ensure full height columns
 	if isActive {
-		result = activeColumnStyle.Width(width).Render(columnContent)
+		result = activeColumnStyle.Width(width).Height(height).Render(columnContent)
 	} else {
-		result = inactiveColumnStyle.Width(width).Render(columnContent)
+		result = inactiveColumnStyle.Width(width).Height(height).Render(columnContent)
 	}
 
 	resultLineCount := strings.Count(result, "\n") + 1


### PR DESCRIPTION
## Summary
This PR introduces several enhancements to the Firestore TUI browser:
- **Jump to Path (Ctrl+g):** Added a new shortcut to open a modal input dialog, allowing users to directly type and jump to a specific Firestore path (collection or document).
- **Full Height Columns:** Fixed the layout logic to ensure columns always occupy the full available vertical space, improving the visual consistency of the TUI.
- **Robust Path Handling:** Improved input handling for paths to correctly identify documents vs. collections and handle edge cases like root navigation.
- **Documentation:** Updated the README and help footer to include the new navigation control.

## Changes
- `pkg/cmd/browse/model.go`: Added input mode state and text input model.
- `pkg/cmd/browse/update.go`: Implemented `Ctrl+g` handler, input processing, and navigation logic.
- `pkg/cmd/browse/view.go`: Added modal dialog rendering and fixed column height calculation.
- `pkg/cmd/browse/root.go`: Initialized text input component.
- `README.md`: Documented the new shortcut.