### PR TITLE
feat: add vim-style clipboard copy commands to browse TUI

### DIFF
--- a/pkg/cmd/browse/clipboard.go
+++ b/pkg/cmd/browse/clipboard.go
@@ -97,6 +97,48 @@ func (m Model) handleCopyAlternate() (tea.Model, tea.Cmd) {
 	return m, clearStatusAfterDelay()
 }
 
+// handleCopyDocument copies the entire document contents as JSON
+func (m Model) handleCopyDocument() (tea.Model, tea.Cmd) {
+	// Verify we're viewing a document
+	if m.activeColumn >= len(m.columns) {
+		m.statusMsg = "No document to copy"
+		m.statusMsgTime = time.Now()
+		return m, clearStatusAfterDelay()
+	}
+
+	col := m.columns[m.activeColumn]
+
+	// Check if current column is a document
+	if !col.isDoc {
+		m.statusMsg = "Can only copy document contents when viewing a document"
+		m.statusMsgTime = time.Now()
+		return m, clearStatusAfterDelay()
+	}
+
+	// Get document content
+	contentToCopy := col.docContent
+	if contentToCopy == "" {
+		contentToCopy = "{}"
+	}
+
+	// Attempt to write to clipboard
+	err := clipboard.WriteAll(contentToCopy)
+	if err != nil {
+		m.statusMsg = fmt.Sprintf("Copy failed: %v", err)
+		m.statusMsgTime = time.Now()
+		logDebug("Clipboard write error: %v", err)
+		return m, clearStatusAfterDelay()
+	}
+
+	// Success! Show size of copied content
+	size := len(contentToCopy)
+	m.statusMsg = fmt.Sprintf("Copied document (%d bytes)", size)
+	m.statusMsgTime = time.Now()
+	logDebug("Copied document to clipboard: %d bytes", size)
+
+	return m, clearStatusAfterDelay()
+}
+
 // clearStatusAfterDelay returns a command that sends clearStatusMsg after 3 seconds
 func clearStatusAfterDelay() tea.Cmd {
 	return tea.Tick(3*time.Second, func(t time.Time) tea.Msg {

--- a/pkg/cmd/browse/clipboard.go
+++ b/pkg/cmd/browse/clipboard.go
@@ -1,0 +1,113 @@
+package browse
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/atotto/clipboard"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// handleCopy copies the appropriate content based on current selection
+func (m Model) handleCopy() (tea.Model, tea.Cmd) {
+	item := m.getSelectedItem()
+	if item == nil {
+		m.statusMsg = "Nothing to copy"
+		m.statusMsgTime = time.Now()
+		return m, clearStatusAfterDelay()
+	}
+
+	var contentToCopy string
+
+	if item.isData {
+		// For data fields in tree view, copy the value
+		contentToCopy = item.valueStr
+
+		// Special handling for different data types
+		switch item.dataType {
+		case "string", "number", "bool", "null":
+			// Use the string representation
+			contentToCopy = item.valueStr
+		case "object", "array":
+			// For complex types, inform user these can't be copied directly
+			m.statusMsg = "Cannot copy object/array (expand to copy fields)"
+			m.statusMsgTime = time.Now()
+			return m, clearStatusAfterDelay()
+		}
+	} else {
+		// For documents/collections, copy the full Firestore path
+		contentToCopy = item.path
+	}
+
+	// Attempt to write to clipboard
+	err := clipboard.WriteAll(contentToCopy)
+	if err != nil {
+		m.statusMsg = fmt.Sprintf("Copy failed: %v", err)
+		m.statusMsgTime = time.Now()
+		logDebug("Clipboard write error: %v", err)
+		return m, clearStatusAfterDelay()
+	}
+
+	// Success!
+	m.statusMsg = fmt.Sprintf("Copied: %s", truncateForDisplay(contentToCopy, 50))
+	m.statusMsgTime = time.Now()
+	logDebug("Copied to clipboard: %s", contentToCopy)
+
+	return m, clearStatusAfterDelay()
+}
+
+// handleCopyAlternate copies the ID/key based on current selection
+// For documents/collections: copies just the ID
+// For data fields: copies the field name/key
+func (m Model) handleCopyAlternate() (tea.Model, tea.Cmd) {
+	item := m.getSelectedItem()
+	if item == nil {
+		m.statusMsg = "Nothing to copy"
+		m.statusMsgTime = time.Now()
+		return m, clearStatusAfterDelay()
+	}
+
+	var contentToCopy string
+	var description string
+
+	if item.isData {
+		// For data fields in tree view, copy the key/field name
+		contentToCopy = item.key
+		description = "key"
+	} else {
+		// For documents/collections, copy just the ID
+		contentToCopy = item.id
+		description = "ID"
+	}
+
+	// Attempt to write to clipboard
+	err := clipboard.WriteAll(contentToCopy)
+	if err != nil {
+		m.statusMsg = fmt.Sprintf("Copy failed: %v", err)
+		m.statusMsgTime = time.Now()
+		logDebug("Clipboard write error: %v", err)
+		return m, clearStatusAfterDelay()
+	}
+
+	// Success!
+	m.statusMsg = fmt.Sprintf("Copied %s: %s", description, truncateForDisplay(contentToCopy, 45))
+	m.statusMsgTime = time.Now()
+	logDebug("Copied %s to clipboard: %s", description, contentToCopy)
+
+	return m, clearStatusAfterDelay()
+}
+
+// clearStatusAfterDelay returns a command that sends clearStatusMsg after 3 seconds
+func clearStatusAfterDelay() tea.Cmd {
+	return tea.Tick(3*time.Second, func(t time.Time) tea.Msg {
+		return clearStatusMsg{}
+	})
+}
+
+// truncateForDisplay truncates a string for display in status
+func truncateForDisplay(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen-3] + "..."
+}

--- a/pkg/cmd/browse/model.go
+++ b/pkg/cmd/browse/model.go
@@ -2,6 +2,7 @@ package browse
 
 import (
 	"context"
+	"time"
 
 	"cloud.google.com/go/firestore"
 	"github.com/charmbracelet/bubbles/textinput"
@@ -32,6 +33,12 @@ type Model struct {
 	// Path input
 	mode      InputMode
 	textInput textinput.Model
+
+	// Clipboard copy state
+	lastKeyPress  string    // Track last key pressed for double-tap
+	lastKeyTime   time.Time // Timestamp of last key press
+	statusMsg     string    // Status message to display
+	statusMsgTime time.Time // When status message was set
 }
 
 // Column represents a single column in the Miller columns layout
@@ -80,6 +87,13 @@ type fetchedColumnMsg struct {
 type errorMsg struct {
 	err error
 }
+
+type statusMsg struct {
+	message string
+}
+
+type clearStatusMsg struct{}
+
 
 // Init initializes the model
 func (m Model) Init() tea.Cmd {

--- a/pkg/cmd/browse/styles.go
+++ b/pkg/cmd/browse/styles.go
@@ -71,6 +71,12 @@ var (
 			Foreground(colorYellow).
 			Italic(true)
 
+	// Status message style
+	statusStyle = lipgloss.NewStyle().
+			Foreground(colorGreen).
+			Italic(true).
+			Padding(0, 1)
+
 	// Tree View Data Type Styles
 	treeKeyStyle = lipgloss.NewStyle().
 			Foreground(lipgloss.Color("205")) // Hot Pink for keys

--- a/pkg/cmd/browse/update.go
+++ b/pkg/cmd/browse/update.go
@@ -155,6 +155,16 @@ func (m Model) handleKeyPress(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
+	// Check for 'ya' sequence (yank all - copy entire document)
+	if currentKey == "a" {
+		if m.lastKeyPress == "y" && currentTime.Sub(m.lastKeyTime) < 500*time.Millisecond {
+			// 'ya' sequence detected! Reset state and copy document
+			m.lastKeyPress = ""
+			m.lastKeyTime = time.Time{}
+			return m.handleCopyDocument()
+		}
+	}
+
 	// Check for shift+y (Y - copy ID/key)
 	if currentKey == "Y" {
 		m.lastKeyPress = ""

--- a/pkg/cmd/browse/update.go
+++ b/pkg/cmd/browse/update.go
@@ -2,6 +2,7 @@ package browse
 
 import (
 	"strings"
+	"time"
 
 	"github.com/charmbracelet/bubbles/textinput"
 	"github.com/charmbracelet/bubbles/viewport"
@@ -122,6 +123,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.err = msg.err
 		m.loading = false
 		return m, nil
+
+	case clearStatusMsg:
+		// Clear status message if it's old enough
+		if time.Since(m.statusMsgTime) >= 3*time.Second {
+			m.statusMsg = ""
+		}
+		return m, nil
 	}
 
 	return m, nil
@@ -129,6 +137,35 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 // handleKeyPress processes keyboard input
 func (m Model) handleKeyPress(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	// Track key press for double-tap detection
+	currentKey := msg.String()
+	currentTime := time.Now()
+
+	// Check for double 'y' tap (yy - vim yank)
+	if currentKey == "y" {
+		if m.lastKeyPress == "y" && currentTime.Sub(m.lastKeyTime) < 500*time.Millisecond {
+			// Double tap detected! Reset state and perform copy
+			m.lastKeyPress = ""
+			m.lastKeyTime = time.Time{}
+			return m.handleCopy()
+		}
+		// First 'y' press - track it
+		m.lastKeyPress = currentKey
+		m.lastKeyTime = currentTime
+		return m, nil
+	}
+
+	// Check for shift+y (Y - copy ID/key)
+	if currentKey == "Y" {
+		m.lastKeyPress = ""
+		return m.handleCopyAlternate()
+	}
+
+	// Any other key resets the double-tap tracking
+	if currentKey != "shift" && currentKey != "ctrl" && currentKey != "alt" {
+		m.lastKeyPress = ""
+	}
+
 	switch msg.String() {
 	// Quit
 	case "q", "esc", "ctrl+c":

--- a/pkg/cmd/browse/view.go
+++ b/pkg/cmd/browse/view.go
@@ -54,7 +54,7 @@ func (m Model) View() string {
 
 	// Footer
 	footer := footerStyle.Render(
-		"j/k: Up/Down  h/l: Back/Forward  g/G: Top/Bottom  Ctrl+d/u: Scroll  Ctrl+g: Go to  yy: Copy  Y: Copy ID/Key  r: Refresh  q: Quit",
+		"j/k: Up/Down  h/l: Back/Forward  g/G: Top/Bottom  Ctrl+d/u: Scroll  Ctrl+g: Go to  yy: Copy  Y: Copy ID/Key  ya: Copy Doc  r: Refresh  q: Quit",
 	)
 
 	// Error message

--- a/pkg/cmd/browse/view.go
+++ b/pkg/cmd/browse/view.go
@@ -54,7 +54,7 @@ func (m Model) View() string {
 
 	// Footer
 	footer := footerStyle.Render(
-		"j/k: Up/Down  h/l: Back/Forward  g/G: Top/Bottom  Ctrl+d/u: Scroll  Ctrl+g: Go to  r: Refresh  q: Quit",
+		"j/k: Up/Down  h/l: Back/Forward  g/G: Top/Bottom  Ctrl+d/u: Scroll  Ctrl+g: Go to  yy: Copy  Y: Copy ID/Key  r: Refresh  q: Quit",
 	)
 
 	// Error message
@@ -125,6 +125,66 @@ func (m Model) View() string {
 		// Or better: render the main view, then if we could overlay...
 		// But string overlay is hard.
 		// Let's just return the dialog centered. It's a "modal" mode.
+	}
+
+	// Overlay status notification if present (floating window)
+	if m.statusMsg != "" {
+		// Create notification box with border
+		notificationStyle := lipgloss.NewStyle().
+			Border(lipgloss.RoundedBorder()).
+			BorderForeground(colorGreen).
+			Background(lipgloss.Color("235")). // Dark background
+			Foreground(colorGreen).
+			Padding(0, 1).
+			Bold(true)
+
+		notification := notificationStyle.Render(m.statusMsg)
+
+		// Split content into lines
+		lines := strings.Split(content, "\n")
+
+		// Calculate position near bottom but above footer
+		// Footer is typically the last line, so place notification a few lines above
+		notificationLine := len(lines) - 3
+		if notificationLine < 2 {
+			notificationLine = 2 // Minimum position from top
+		}
+
+		// Make sure we don't go beyond the content
+		if notificationLine >= len(lines) {
+			notificationLine = len(lines) - 1
+		}
+
+		// Position notification at bottom right
+		notificationLines := strings.Split(notification, "\n")
+
+		// Overlay each line of the notification at the right edge
+		for i, notifLine := range notificationLines {
+			linePos := notificationLine + i
+			if linePos < len(lines) {
+				notifWidth := lipgloss.Width(notifLine)
+				existingLine := lines[linePos]
+				existingWidth := lipgloss.Width(existingLine)
+
+				// Calculate padding to align to the right
+				leftPad := existingWidth - notifWidth - 2 // -2 for a small margin from right edge
+				if leftPad < 0 {
+					leftPad = 0
+				}
+
+				// Align to right by adding left padding
+				if leftPad+notifWidth <= existingWidth {
+					// Right-align with padding
+					lines[linePos] = strings.Repeat(" ", leftPad) + notifLine
+				} else {
+					// Notification is wider than existing line, just place it
+					lines[linePos] = notifLine
+				}
+			}
+		}
+
+		// Rejoin the content
+		content = strings.Join(lines, "\n")
 	}
 
 	return content


### PR DESCRIPTION
## Summary
Add comprehensive vim-style clipboard copy functionality to the browse command with three keybindings:
- `yy` - Copy full Firestore path for documents/collections, or field value for data nodes
- `Y` - Copy document ID or field key name
- `ya` - Copy entire document contents as JSON

## Features
- **Vim-style keybindings**: Uses familiar vim yank patterns for intuitive clipboard operations
- **Context-aware copying**: Automatically determines what to copy based on current selection
- **Floating notifications**: Success/error messages appear in bottom-right corner without disrupting layout
- **Auto-clearing feedback**: Status messages disappear after 3 seconds
- **Comprehensive data type support**: Handles strings, numbers, booleans, null values
- **Graceful error handling**: Clear messages for objects/arrays and invalid contexts
- **Byte count display**: Shows size for document copies

## Technical Implementation
- Double-tap detection with 500ms window for `yy`
- Key sequence detection for `ya` (y followed by a)
- Single key press for `Y` (shift+y)
- Floating notification overlay system that doesn't affect layout
- Uses existing `github.com/atotto/clipboard` library

## Testing
All keybindings tested for:
- Path/value copying with `yy`
- ID/key copying with `Y`
- Full document JSON copying with `ya`
- Error handling for unsupported types
- Timing validation for key sequences
- Layout stability with floating notifications

## Related Commits
- d71f616 feat: add clipboard copy functionality to browse command
- e834469 feat: add ya keybinding to copy entire document as JSON