### PR TITLE
feat: add document metadata section to display timestamps

### DIFF
--- a/pkg/cmd/browse/firestore.go
+++ b/pkg/cmd/browse/firestore.go
@@ -98,6 +98,7 @@ func fetchColumnData(client *firestore.Client, path string, isDoc bool, columnIn
 		sections := []Section{}
 		docContent := ""
 		var docData map[string]interface{}
+		docMetadata := map[string]string{}
 
 		if path == "" {
 			// Root: fetch root collections
@@ -193,6 +194,18 @@ func fetchColumnData(client *firestore.Client, path string, isDoc bool, columnIn
 				return errorMsg{err: err}
 			}
 
+			// Extract metadata
+			docMetadata = map[string]string{}
+			if !snap.CreateTime.IsZero() {
+				docMetadata["Created"] = snap.CreateTime.Local().Format("2006-01-02 15:04:05")
+			}
+			if !snap.UpdateTime.IsZero() {
+				docMetadata["Updated"] = snap.UpdateTime.Local().Format("2006-01-02 15:04:05")
+			}
+			if !snap.ReadTime.IsZero() {
+				docMetadata["Read"] = snap.ReadTime.Local().Format("2006-01-02 15:04:05")
+			}
+
 			// Format as JSON
 			docData = snap.Data()
 			var buf bytes.Buffer
@@ -213,6 +226,27 @@ func fetchColumnData(client *firestore.Client, path string, isDoc bool, columnIn
 					hidden: false,
 				})
 			}
+
+			// Create Metadata section
+			if len(docMetadata) > 0 {
+				var metadataItems []ListItem
+				// Sort keys for consistent order
+				keys := []string{"Created", "Updated", "Read"}
+				for _, k := range keys {
+					if v, ok := docMetadata[k]; ok {
+						metadataItems = append(metadataItems, ListItem{
+							id:     fmt.Sprintf("%s: %s", k, v),
+							isData: false,
+							isDoc:  false,
+						})
+					}
+				}
+				sections = append(sections, Section{
+					title:  "Metadata",
+					items:  metadataItems,
+					hidden: false,
+				})
+			}
 		}
 
 		result := fetchedColumnMsg{
@@ -220,6 +254,7 @@ func fetchColumnData(client *firestore.Client, path string, isDoc bool, columnIn
 			sections:    sections,
 			docContent:  docContent,
 			docData:     docData,
+			docMetadata: docMetadata,
 		}
 		logDebug("fetchColumnData completed: columnIndex=%d, sections=%d, docContentLen=%d, docData keys=%d",
 			columnIndex, len(sections), len(docContent), len(docData))

--- a/pkg/cmd/browse/model.go
+++ b/pkg/cmd/browse/model.go
@@ -48,6 +48,7 @@ type Column struct {
 	sections     []Section              // Documents and/or Subcollections sections
 	docContent   string                 // Raw JSON content (only for document columns)
 	docData      map[string]interface{} // Parsed data map
+	docMetadata  map[string]string      // Document metadata (CreateTime, UpdateTime, etc.)
 	viewport     viewport.Model         // Scrollable viewport for document content
 	cursor       int                    // Selected index across all items
 	scrollOffset int                    // Scroll position for lists
@@ -83,6 +84,7 @@ type fetchedColumnMsg struct {
 	sections    []Section
 	docContent  string
 	docData     map[string]interface{}
+	docMetadata map[string]string
 }
 
 type errorMsg struct {

--- a/pkg/cmd/browse/update.go
+++ b/pkg/cmd/browse/update.go
@@ -103,6 +103,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.columns[msg.columnIndex].sections = msg.sections
 			m.columns[msg.columnIndex].docContent = msg.docContent
 			m.columns[msg.columnIndex].docData = msg.docData
+			m.columns[msg.columnIndex].docMetadata = msg.docMetadata
 			m.columns[msg.columnIndex].scrollOffset = 0 // Reset scroll to top when new data arrives
 
 			// Initialize viewport if this is a document column
@@ -153,6 +154,27 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 						items: buildTreeNodes(msg.data),
 					},
 				}
+
+				// Add existing Metadata section if present
+				if len(col.docMetadata) > 0 {
+					var metadataItems []ListItem
+					keys := []string{"Created", "Updated", "Read"}
+					for _, k := range keys {
+						if v, ok := col.docMetadata[k]; ok {
+							metadataItems = append(metadataItems, ListItem{
+								id:     fmt.Sprintf("%s: %s", k, v),
+								isData: false,
+								isDoc:  false,
+							})
+						}
+					}
+					sections = append(sections, Section{
+						title:  "Metadata",
+						items:  metadataItems,
+						hidden: false,
+					})
+				}
+
 				col.sections = sections
 			}
 		}


### PR DESCRIPTION
## Summary
- Adds a new "Metadata" section to document columns that displays Firestore document timestamps
- Metadata section appears below the "Data" section showing Created, Updated, and Read timestamps
- Timestamps are formatted as `YYYY-MM-DD HH:MM:SS` for readability
- Metadata is preserved when documents are edited and refreshed when reloading

## Implementation
- Added `docMetadata` field to `Column` and `fetchedColumnMsg` structs
- Extract timestamps from Firestore `DocumentSnapshot` (CreateTime, UpdateTime, ReadTime)
- Created "Metadata" section with formatted timestamp entries
- Updated state management to store and preserve metadata across operations

## Test plan
- [x] Build completes without errors
- [x] Navigate to a document and verify Metadata section appears below Data section
- [x] Verify three timestamp fields display correctly (Created, Updated, Read)
- [x] Press 'r' to refresh and verify ReadTime updates
- [x] Press 'e' to edit document and verify Metadata section persists
- [x] Navigate with j/k keys through metadata items
- [x] Copy metadata values using yy/Y/ya keys