### PR TITLE
feat(auth): add auth command with built-in OAuth2 login flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,38 @@ Firestore is a command line utility to facilitate operations with Firestore from
 
 ## Usage
 
-Currently both `PROJECT_ID` and `GOOGLE_APPLICATION_CREDENTIALS` are required.
+### Authentication
 
+Log in with your Google account:
+
+```bash
+firestore auth login
 ```
-export PROJECT_ID=my-project
-export GOOGLE_APPLICATION_CREDENTIALS=/path/to/credentials.json
 
+This opens a browser-based OAuth2 flow and saves Application Default Credentials locally. No external tools (like `gcloud`) are required.
+
+You can check your authentication status or revoke credentials at any time:
+
+```bash
+firestore auth status
+firestore auth revoke
+```
+
+Alternatively, you can set `GOOGLE_APPLICATION_CREDENTIALS` to point to a service account key file.
+
+### Project
+
+Set the project via the `--project` flag or the `PROJECT_ID` environment variable:
+
+```bash
+export PROJECT_ID=my-project
+# or
+firestore -p my-project <command>
+```
+
+### Examples
+
+```bash
 # copying a document
 firestore document cp /my-collection/my-document /my-collection/another-document
 

--- a/go.mod
+++ b/go.mod
@@ -4,13 +4,13 @@ go 1.24.0
 
 require (
 	cloud.google.com/go/firestore v1.12.0
+	github.com/atotto/clipboard v0.1.4
 	github.com/charmbracelet/bubbles v0.21.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
 )
 
 require (
-	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc // indirect
 	github.com/charmbracelet/x/ansi v0.10.1 // indirect
@@ -46,7 +46,7 @@ require (
 	go.opencensus.io v0.24.0 // indirect
 	golang.org/x/crypto v0.9.0 // indirect
 	golang.org/x/net v0.10.0 // indirect
-	golang.org/x/oauth2 v0.8.0 // indirect
+	golang.org/x/oauth2 v0.8.0
 	golang.org/x/sync v0.11.0 // indirect
 	golang.org/x/sys v0.36.0 // indirect
 	golang.org/x/text v0.9.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,8 @@ github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z
 github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
+github.com/aymanbagabas/go-udiff v0.2.0 h1:TK0fH4MteXUDspT88n8CKzvK0X9O2xu9yQjWpi6yML8=
+github.com/aymanbagabas/go-udiff v0.2.0/go.mod h1:RE4Ex0qsGkTAJoQdQQCA0uG+nAzJO/pI/QwceO5fgrA=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/charmbracelet/bubbles v0.21.0 h1:9TdC97SdRVg/1aaXNVWfFH3nnLAwOXr8Fn6u6mfQdFs=
@@ -30,6 +32,8 @@ github.com/charmbracelet/x/ansi v0.10.1 h1:rL3Koar5XvX0pHGfovN03f5cxLbCF2YvLeyz7
 github.com/charmbracelet/x/ansi v0.10.1/go.mod h1:3RQDQ6lDnROptfpWuUVIUG64bD2g2BgntdxH0Ya5TeE=
 github.com/charmbracelet/x/cellbuf v0.0.13-0.20250311204145-2c3ea96c31dd h1:vy0GVL4jeHEwG5YOXDmi86oYw2yuYUGqz6a8sLwg0X8=
 github.com/charmbracelet/x/cellbuf v0.0.13-0.20250311204145-2c3ea96c31dd/go.mod h1:xe0nKWGd3eJgtqZRaN9RjMtK7xUYchjzPr7q6kcvCCs=
+github.com/charmbracelet/x/exp/golden v0.0.0-20241011142426-46044092ad91 h1:payRxjMjKgx2PaCWLZ4p3ro9y97+TVLZNaRZgJwSVDQ=
+github.com/charmbracelet/x/exp/golden v0.0.0-20241011142426-46044092ad91/go.mod h1:wDlXFlCrmJ8J+swcL/MnGUuYnqgQdW9rhSD61oNMb6U=
 github.com/charmbracelet/x/term v0.2.1 h1:AQeHeLZ1OqSXhrAWpYUtZyX1T3zVxfpZuEQMIQaGIAQ=
 github.com/charmbracelet/x/term v0.2.1/go.mod h1:oQ4enTYFV7QN4m0i9mzHrViD7TQKvNEEkHUMCmsxdUg=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
@@ -91,6 +95,8 @@ github.com/googleapis/gax-go/v2 v2.11.0/go.mod h1:DxmR61SGKkGLa2xigwuZIQpkCI2S5i
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
+github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=
 github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=

--- a/pkg/cmd/auth/auth.go
+++ b/pkg/cmd/auth/auth.go
@@ -1,0 +1,30 @@
+package auth
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func NewAuthCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "auth",
+		Short: "Manage authentication for Firestore CLI",
+		Long: `Set up and manage Google Cloud credentials used by the Firestore CLI.
+
+This tool uses Application Default Credentials (ADC) to authenticate with
+Google Cloud. The auth command helps you configure these credentials without
+needing to manually install or configure the gcloud CLI.`,
+		// Override root's PersistentPreRunE — auth commands must work without
+		// existing credentials since their purpose is to create them.
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			return nil
+		},
+	}
+
+	cmd.AddCommand(
+		NewLoginCmd(),
+		NewStatusCmd(),
+		NewRevokeCmd(),
+	)
+
+	return cmd
+}

--- a/pkg/cmd/auth/login.go
+++ b/pkg/cmd/auth/login.go
@@ -1,0 +1,202 @@
+package auth
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"time"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/oauth2"
+)
+
+// Well-known OAuth2 client credentials for Application Default Credentials.
+// These are the same public credentials used by the gcloud CLI and are
+// documented in Google's source code.
+const (
+	adcClientID     = "764086051850-6qr4p6gpi6hn506pt8ejuq83di341hur.apps.googleusercontent.com"
+	adcClientSecret = "d-FL95Q19q7MQmFpd7hHD0Ty"
+)
+
+var adcScopes = []string{
+	"https://www.googleapis.com/auth/cloud-platform",
+	"https://www.googleapis.com/auth/userinfo.email",
+	"openid",
+}
+
+// adcCredentials is the JSON format for Application Default Credentials files.
+type adcCredentials struct {
+	ClientID     string `json:"client_id"`
+	ClientSecret string `json:"client_secret"`
+	RefreshToken string `json:"refresh_token"`
+	Type         string `json:"type"`
+}
+
+func NewLoginCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "login",
+		Short: "Authenticate with Google Cloud",
+		Long: `Set up Application Default Credentials (ADC) for accessing Firestore.
+
+This command runs an OAuth2 login flow in your browser and stores credentials
+locally. No external tools (like gcloud) are required.
+
+After logging in, set your project with:
+  export PROJECT_ID=my-project
+or pass it with the --project flag.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// Start a local HTTP server on a random port to receive the OAuth callback.
+			listener, err := net.Listen("tcp", "localhost:0")
+			if err != nil {
+				return fmt.Errorf("failed to start local server: %w", err)
+			}
+			defer listener.Close()
+
+			port := listener.Addr().(*net.TCPAddr).Port
+			redirectURL := fmt.Sprintf("http://localhost:%d", port)
+
+			config := &oauth2.Config{
+				ClientID:     adcClientID,
+				ClientSecret: adcClientSecret,
+				Endpoint: oauth2.Endpoint{
+					AuthURL:  "https://accounts.google.com/o/oauth2/auth",
+					TokenURL: "https://oauth2.googleapis.com/token",
+				},
+				RedirectURL: redirectURL,
+				Scopes:      adcScopes,
+			}
+
+			state, err := generateState()
+			if err != nil {
+				return fmt.Errorf("failed to generate state: %w", err)
+			}
+
+			codeCh := make(chan string, 1)
+			errCh := make(chan error, 1)
+
+			mux := http.NewServeMux()
+			mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+				q := r.URL.Query()
+				// Ignore requests without OAuth parameters (e.g., favicon).
+				if q.Get("code") == "" && q.Get("error") == "" {
+					return
+				}
+
+				if q.Get("state") != state {
+					errCh <- fmt.Errorf("state mismatch in OAuth callback")
+					http.Error(w, "State mismatch", http.StatusBadRequest)
+					return
+				}
+				if errMsg := q.Get("error"); errMsg != "" {
+					errCh <- fmt.Errorf("authorization denied: %s", errMsg)
+					fmt.Fprintf(w, "<html><body><h2>Authorization failed</h2><p>%s</p><p>You can close this window.</p></body></html>", errMsg)
+					return
+				}
+
+				code := q.Get("code")
+				fmt.Fprint(w, "<html><body><h2>Authentication successful!</h2><p>You can close this window and return to the terminal.</p></body></html>")
+				codeCh <- code
+			})
+
+			server := &http.Server{Handler: mux}
+			go server.Serve(listener)
+			defer server.Shutdown(context.Background())
+
+			authURL := config.AuthCodeURL(state, oauth2.AccessTypeOffline, oauth2.SetAuthURLParam("prompt", "consent"))
+
+			fmt.Println("Your browser will open to authenticate with Google Cloud.")
+			fmt.Println()
+
+			if err := openBrowser(authURL); err != nil {
+				fmt.Println("Could not open browser automatically. Please visit this URL:")
+				fmt.Println()
+				fmt.Println("  " + authURL)
+				fmt.Println()
+			}
+
+			fmt.Println("Waiting for authentication...")
+
+			var code string
+			select {
+			case code = <-codeCh:
+			case err := <-errCh:
+				return err
+			case <-time.After(5 * time.Minute):
+				return fmt.Errorf("authentication timed out after 5 minutes")
+			}
+
+			token, err := config.Exchange(cmd.Context(), code)
+			if err != nil {
+				return fmt.Errorf("token exchange failed: %w", err)
+			}
+
+			if err := saveADCCredentials(token.RefreshToken); err != nil {
+				return err
+			}
+
+			fmt.Println()
+			fmt.Println("Authentication successful!")
+			fmt.Printf("Credentials saved to: %s\n", wellKnownADCPath())
+			fmt.Println()
+			fmt.Println("Make sure to set your project:")
+			fmt.Println("  export PROJECT_ID=my-project")
+			fmt.Println("  # or use: firestore -p my-project <command>")
+
+			return nil
+		},
+	}
+}
+
+func generateState() (string, error) {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}
+
+func openBrowser(url string) error {
+	switch runtime.GOOS {
+	case "darwin":
+		return exec.Command("open", url).Start()
+	case "linux":
+		return exec.Command("xdg-open", url).Start()
+	case "windows":
+		return exec.Command("cmd", "/c", "start", url).Start()
+	default:
+		return fmt.Errorf("unsupported platform")
+	}
+}
+
+func saveADCCredentials(refreshToken string) error {
+	creds := adcCredentials{
+		ClientID:     adcClientID,
+		ClientSecret: adcClientSecret,
+		RefreshToken: refreshToken,
+		Type:         "authorized_user",
+	}
+
+	data, err := json.MarshalIndent(creds, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal credentials: %w", err)
+	}
+
+	path := wellKnownADCPath()
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return fmt.Errorf("failed to create credentials directory: %w", err)
+	}
+
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		return fmt.Errorf("failed to write credentials: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/cmd/auth/revoke.go
+++ b/pkg/cmd/auth/revoke.go
@@ -1,0 +1,56 @@
+package auth
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+func NewRevokeCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "revoke",
+		Short: "Revoke Application Default Credentials",
+		Long:  `Revoke the locally stored Application Default Credentials and remove the credential file.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			adcPath := wellKnownADCPath()
+
+			data, err := os.ReadFile(adcPath)
+			if err != nil {
+				if os.IsNotExist(err) {
+					fmt.Println("No credentials to revoke.")
+					return nil
+				}
+				return fmt.Errorf("failed to read credentials: %w", err)
+			}
+
+			// Extract the refresh token so we can revoke it server-side.
+			var creds struct {
+				RefreshToken string `json:"refresh_token"`
+			}
+			if err := json.Unmarshal(data, &creds); err == nil && creds.RefreshToken != "" {
+				resp, err := http.PostForm("https://oauth2.googleapis.com/revoke", url.Values{
+					"token": {creds.RefreshToken},
+				})
+				if err != nil {
+					fmt.Printf("Warning: could not reach revocation endpoint: %v\n", err)
+				} else {
+					resp.Body.Close()
+					if resp.StatusCode != http.StatusOK {
+						fmt.Printf("Warning: token revocation returned status %d (token may already be expired)\n", resp.StatusCode)
+					}
+				}
+			}
+
+			if err := os.Remove(adcPath); err != nil {
+				return fmt.Errorf("failed to remove credentials file: %w", err)
+			}
+
+			fmt.Println("Credentials revoked.")
+			return nil
+		},
+	}
+}

--- a/pkg/cmd/auth/status.go
+++ b/pkg/cmd/auth/status.go
@@ -1,0 +1,85 @@
+package auth
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+
+	"github.com/spf13/cobra"
+)
+
+func NewStatusCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "status",
+		Short: "Check authentication status",
+		Long:  `Check whether Application Default Credentials are configured and display the credential type and account info.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// Check GOOGLE_APPLICATION_CREDENTIALS env var first
+			if sa := os.Getenv("GOOGLE_APPLICATION_CREDENTIALS"); sa != "" {
+				info, err := readCredentialFile(sa)
+				if err != nil {
+					return fmt.Errorf("GOOGLE_APPLICATION_CREDENTIALS is set to %s but cannot be read: %w", sa, err)
+				}
+				printCredentialInfo("service_account (via GOOGLE_APPLICATION_CREDENTIALS)", sa, info)
+				return nil
+			}
+
+			// Check ADC well-known location
+			adcPath := wellKnownADCPath()
+			info, err := readCredentialFile(adcPath)
+			if err != nil {
+				fmt.Println("Not authenticated.")
+				fmt.Println()
+				fmt.Println("Run: firestore auth login")
+				return nil
+			}
+
+			printCredentialInfo("application_default_credentials", adcPath, info)
+			return nil
+		},
+	}
+}
+
+// wellKnownADCPath returns the path where gcloud stores ADC credentials.
+func wellKnownADCPath() string {
+	if runtime.GOOS == "windows" {
+		return filepath.Join(os.Getenv("APPDATA"), "gcloud", "application_default_credentials.json")
+	}
+	return filepath.Join(os.Getenv("HOME"), ".config", "gcloud", "application_default_credentials.json")
+}
+
+// credentialInfo holds the fields we care about from a credential JSON file.
+type credentialInfo struct {
+	Type     string `json:"type"`
+	ClientID string `json:"client_id"`
+	Account  string `json:"client_email"`
+	Project  string `json:"quota_project_id"`
+}
+
+func readCredentialFile(path string) (credentialInfo, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return credentialInfo{}, err
+	}
+	var info credentialInfo
+	if err := json.Unmarshal(data, &info); err != nil {
+		return credentialInfo{}, fmt.Errorf("invalid credential file: %w", err)
+	}
+	return info, nil
+}
+
+func printCredentialInfo(source, path string, info credentialInfo) {
+	fmt.Printf("Authenticated (%s)\n", source)
+	fmt.Printf("  Credential file: %s\n", path)
+	if info.Type != "" {
+		fmt.Printf("  Type:            %s\n", info.Type)
+	}
+	if info.Account != "" {
+		fmt.Printf("  Account:         %s\n", info.Account)
+	}
+	if info.Project != "" {
+		fmt.Printf("  Quota project:   %s\n", info.Project)
+	}
+}

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -7,6 +7,7 @@ import (
 
 	"cloud.google.com/go/firestore"
 
+	"github.com/gugahoi/firestore/pkg/cmd/auth"
 	"github.com/gugahoi/firestore/pkg/cmd/browse"
 	"github.com/gugahoi/firestore/pkg/cmd/collection"
 	"github.com/gugahoi/firestore/pkg/cmd/document"
@@ -62,6 +63,7 @@ var host string
 func init() {
 	rootCmd.PersistentFlags().StringVarP(&projectId, "project", "p", "", "Google Cloud Project")
 	rootCmd.PersistentFlags().StringVar(&host, "host", "", "Firestore host (e.g., localhost:8080 for emulator)")
+	rootCmd.AddCommand(auth.NewAuthCmd())
 	rootCmd.AddCommand(browse.NewBrowseCmd())
 	rootCmd.AddCommand(document.NewDocumentCmd())
 	rootCmd.AddCommand(collection.NewCollectionCmd())


### PR DESCRIPTION
## Summary
- Adds a new `firestore auth` command with `login`, `status`, and `revoke` subcommands
- Implements a full OAuth2 authorization code flow directly (local callback server, browser consent, token exchange) so users don't need to install or configure the gcloud CLI
- Saves credentials in the standard Application Default Credentials location (`~/.config/gcloud/application_default_credentials.json`), compatible with all Google Cloud client libraries
- `revoke` invalidates the token server-side via Google's revocation endpoint before removing the local file

## Test plan
- [x] Run `firestore auth login` — browser opens, consent flow completes, credentials saved
- [x] Run `firestore auth status` — shows credential type, file path, and account info
- [x] Run `firestore auth revoke` — token revoked and file removed
- [x] Run `firestore auth status` after revoke — shows "Not authenticated"
- [x] Run `firestore auth login` then use another command (e.g. `firestore -p <project> collection list /`) to verify credentials work end-to-end
- [x] Run `firestore auth login` without a browser available — URL is printed for manual copy