### PR TITLE
fix(browse): show documents with subcollections but no data

### DIFF
--- a/pkg/cmd/browse/firestore.go
+++ b/pkg/cmd/browse/firestore.go
@@ -11,6 +11,8 @@ import (
 	"cloud.google.com/go/firestore"
 	tea "github.com/charmbracelet/bubbletea"
 	"google.golang.org/api/iterator"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // Helper to build tree nodes from map
@@ -172,6 +174,32 @@ func fetchColumnData(client *firestore.Client, path string, isDoc bool, columnIn
 					metadata: metadata,
 				})
 			}
+			seen := make(map[string]bool, len(items))
+			for _, item := range items {
+				seen[item.id] = true
+			}
+
+			refsIter := colRef.DocumentRefs(ctx)
+			for {
+				ref, err := refsIter.Next()
+				if err == iterator.Done {
+					break
+				}
+				if err != nil {
+					return errorMsg{err: err}
+				}
+				if seen[ref.ID] {
+					continue
+				}
+				docPath := path + "/" + ref.ID
+				items = append(items, ListItem{
+					id:        ref.ID,
+					path:      docPath,
+					isDoc:     true,
+					isMissing: true,
+				})
+			}
+
 			sections = append(sections, Section{
 				title:  "Documents",
 				items:  items,
@@ -211,41 +239,43 @@ func fetchColumnData(client *firestore.Client, path string, isDoc bool, columnIn
 
 			// Fetch document data
 			snap, err := docRef.Get(ctx)
-			if err != nil {
+			if err != nil && status.Code(err) != codes.NotFound {
 				return errorMsg{err: err}
 			}
 
-			// Extract metadata
-			docMetadata = map[string]string{}
-			if !snap.CreateTime.IsZero() {
-				docMetadata["Created"] = snap.CreateTime.Local().Format("2006-01-02 15:04:05")
-			}
-			if !snap.UpdateTime.IsZero() {
-				docMetadata["Updated"] = snap.UpdateTime.Local().Format("2006-01-02 15:04:05")
-			}
-			if !snap.ReadTime.IsZero() {
-				docMetadata["Read"] = snap.ReadTime.Local().Format("2006-01-02 15:04:05")
-			}
+			if snap != nil && snap.Exists() {
+				// Extract metadata
+				docMetadata = map[string]string{}
+				if !snap.CreateTime.IsZero() {
+					docMetadata["Created"] = snap.CreateTime.Local().Format("2006-01-02 15:04:05")
+				}
+				if !snap.UpdateTime.IsZero() {
+					docMetadata["Updated"] = snap.UpdateTime.Local().Format("2006-01-02 15:04:05")
+				}
+				if !snap.ReadTime.IsZero() {
+					docMetadata["Read"] = snap.ReadTime.Local().Format("2006-01-02 15:04:05")
+				}
 
-			// Format as JSON
-			docData = snap.Data()
-			var buf bytes.Buffer
-			encoder := json.NewEncoder(&buf)
-			encoder.SetEscapeHTML(false)
-			encoder.SetIndent("", "  ")
-			if err := encoder.Encode(docData); err != nil {
-				return errorMsg{err: err}
-			}
-			docContent = buf.String()
+				// Format as JSON
+				docData = snap.Data()
+				var buf bytes.Buffer
+				encoder := json.NewEncoder(&buf)
+				encoder.SetEscapeHTML(false)
+				encoder.SetIndent("", "  ")
+				if err := encoder.Encode(docData); err != nil {
+					return errorMsg{err: err}
+				}
+				docContent = buf.String()
 
-			// Build tree nodes for structured view
-			rootNodes := buildTreeNodes(docData)
-			if len(rootNodes) > 0 {
-				sections = append(sections, Section{
-					title:  "Data",
-					items:  rootNodes,
-					hidden: false,
-				})
+				// Build tree nodes for structured view
+				rootNodes := buildTreeNodes(docData)
+				if len(rootNodes) > 0 {
+					sections = append(sections, Section{
+						title:  "Data",
+						items:  rootNodes,
+						hidden: false,
+					})
+				}
 			}
 
 			// Create Metadata section

--- a/pkg/cmd/browse/model.go
+++ b/pkg/cmd/browse/model.go
@@ -75,11 +75,12 @@ type Section struct {
 
 // ListItem represents a single item in a list (document, collection, or data node)
 type ListItem struct {
-	id       string            // Display ID or Key
-	path     string            // Firestore path (for cols/docs) or JSON path (for data)
-	isDoc    bool              // true for documents, false for collections
-	isData   bool              // true if this is a data node
-	metadata map[string]string // CreateTime, etc.
+	id        string            // Display ID or Key
+	path      string            // Firestore path (for cols/docs) or JSON path (for data)
+	isDoc     bool              // true for documents, false for collections
+	isData    bool              // true if this is a data node
+	isMissing bool              // true if document has no data (only subcollections)
+	metadata  map[string]string // CreateTime, etc.
 
 	// Tree view fields
 	key      string

--- a/pkg/cmd/browse/styles.go
+++ b/pkg/cmd/browse/styles.go
@@ -57,6 +57,11 @@ var (
 	docIndicatorStyle = lipgloss.NewStyle().
 				Foreground(colorGreen)
 
+	// Missing document style (documents with no data, only subcollections)
+	missingDocStyle = lipgloss.NewStyle().
+			Foreground(colorGray).
+			Faint(true)
+
 	// Collection indicator style
 	colIndicatorStyle = lipgloss.NewStyle().
 				Foreground(colorBlue)

--- a/pkg/cmd/browse/view.go
+++ b/pkg/cmd/browse/view.go
@@ -432,8 +432,18 @@ func (m Model) renderColumn(col Column, width int, isActive bool) string {
 				}
 
 				line := fmt.Sprintf("%s%s", prefix, displayID)
+				if item.isMissing {
+					line = fmt.Sprintf("%s%s", prefix, missingDocStyle.Render(displayID+" (no data)"))
+				}
 				if itemIndex == col.cursor {
-					line = selectedItemStyle.Render(line)
+					line = selectedItemStyle.Render(
+						fmt.Sprintf("%s%s", prefix, displayID),
+					)
+					if item.isMissing {
+						line = selectedItemStyle.Render(
+							fmt.Sprintf("%s%s (no data)", prefix, displayID),
+						)
+					}
 				}
 
 				content.WriteString(line)


### PR DESCRIPTION
## Summary
- Collections with "missing" documents (no field data, only subcollections) now display those documents by iterating `DocumentRefs()` in addition to `Documents()`
- Missing documents are shown with a dimmed `(no data)` suffix so users can distinguish them from regular documents
- Navigating into a missing document gracefully handles the `NotFound` error and still lists its subcollections

## Test plan
- [x] Browse a collection where all documents have field data — verify no change in behavior
- [x] Browse a collection where some documents have no field data but have subcollections — verify they appear with `(no data)` suffix
- [x] Select a missing document — verify subcollections are listed and navigable
- [x] Verify no errors when navigating into and out of missing documents