### PR TITLE
feat(browse): add document deletion with confirmation

### DIFF
--- a/pkg/cmd/browse/firestore.go
+++ b/pkg/cmd/browse/firestore.go
@@ -92,6 +92,18 @@ func createNode(key string, value interface{}, depth int) ListItem {
 	return item
 }
 
+func deleteDocument(client *firestore.Client, path string, fromDocView bool) tea.Cmd {
+	return func() tea.Msg {
+		ctx := context.Background()
+		docRef := client.Doc(strings.TrimPrefix(path, "/"))
+		_, err := docRef.Delete(ctx)
+		if err != nil {
+			return errorMsg{err: fmt.Errorf("failed to delete document: %w", err)}
+		}
+		return documentDeletedMsg{path: path, fromDocView: fromDocView}
+	}
+}
+
 // fetchColumnData fetches data for a specific column based on path and type
 func fetchColumnData(client *firestore.Client, path string, isDoc bool, columnIndex int, sortField string, sortDirection firestore.Direction) tea.Cmd {
 	return func() tea.Msg {

--- a/pkg/cmd/browse/model.go
+++ b/pkg/cmd/browse/model.go
@@ -17,6 +17,7 @@ const (
 	ModeNormal InputMode = iota
 	ModePathInput
 	ModeSortDialog
+	ModeDeleteConfirm
 )
 
 // Model represents the entire TUI state
@@ -44,6 +45,10 @@ type Model struct {
 	lastKeyTime   time.Time // Timestamp of last key press
 	statusMsg     string    // Status message to display
 	statusMsgTime time.Time // When status message was set
+
+	// Delete confirmation
+	deletePath        string // Path of document pending deletion
+	deleteFromDocView bool   // Whether delete was initiated from a document column
 }
 
 // sortStateEntry stores sort configuration for a collection path
@@ -114,6 +119,11 @@ type clearStatusMsg struct{}
 type documentUpdatedMsg struct {
 	path string
 	data map[string]interface{}
+}
+
+type documentDeletedMsg struct {
+	path        string
+	fromDocView bool // true if delete was initiated from a document column
 }
 
 // getSortParams returns the saved sort field and direction for a given path

--- a/pkg/cmd/browse/root.go
+++ b/pkg/cmd/browse/root.go
@@ -39,6 +39,7 @@ Sorting (collections only):
 
 Editing:
   e                    Edit document in $EDITOR
+  d                    Delete document (with confirmation)
 
 Clipboard:
   yy                   Copy selected value

--- a/pkg/cmd/browse/styles.go
+++ b/pkg/cmd/browse/styles.go
@@ -124,4 +124,10 @@ var (
 	sortHintStyle = lipgloss.NewStyle().
 			Foreground(colorGray).
 			Italic(true)
+
+	deleteDialogStyle = lipgloss.NewStyle().
+				Border(lipgloss.RoundedBorder()).
+				BorderForeground(colorRed).
+				Padding(1, 2).
+				Width(50)
 )

--- a/pkg/cmd/browse/update.go
+++ b/pkg/cmd/browse/update.go
@@ -101,6 +101,26 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, cmd
 		}
 
+		// Handle delete confirmation mode
+		if m.mode == ModeDeleteConfirm {
+			switch msg.String() {
+			case "y", "enter":
+				path := m.deletePath
+				fromDocView := m.deleteFromDocView
+				m.deletePath = ""
+				m.deleteFromDocView = false
+				m.mode = ModeNormal
+				m.loading = true
+				return m, deleteDocument(m.client, path, fromDocView)
+			case "n", "esc", "q":
+				m.deletePath = ""
+				m.deleteFromDocView = false
+				m.mode = ModeNormal
+				return m, nil
+			}
+			return m, nil
+		}
+
 		// Handle normal mode global keys
 		if msg.String() == "ctrl+g" {
 			m.mode = ModePathInput
@@ -229,6 +249,33 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.statusMsgTime = time.Now()
 		m.loading = false
 
+		return m, clearStatusAfterDelay()
+
+	case documentDeletedMsg:
+		m.loading = false
+
+		if msg.fromDocView {
+			// Delete was from a document column — go back to parent collection
+			m.removeLastColumn()
+		}
+
+		// Refresh the now-active column (the parent collection)
+		if m.activeColumn < len(m.columns) {
+			col := m.columns[m.activeColumn]
+			sortField, sortDir := m.getSortParams(col.path)
+
+			m.statusMsg = "Document deleted"
+			m.statusMsgTime = time.Now()
+			m.loading = true
+
+			return m, tea.Batch(
+				fetchColumnData(m.client, col.path, col.isDoc, m.activeColumn, sortField, sortDir),
+				clearStatusAfterDelay(),
+			)
+		}
+
+		m.statusMsg = "Document deleted"
+		m.statusMsgTime = time.Now()
 		return m, clearStatusAfterDelay()
 
 	case launchEditorMsg:
@@ -432,6 +479,32 @@ func (m Model) handleKeyPress(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			sortField, sortDir := m.getSortParams(col.path)
 			return m, fetchColumnData(m.client, col.path, col.isDoc, m.activeColumn, sortField, sortDir)
 		}
+		return m, nil
+
+	case "d":
+		if m.activeColumn >= len(m.columns) {
+			return m, nil
+		}
+
+		col := m.columns[m.activeColumn]
+		var docPath string
+
+		if col.isDoc {
+			docPath = col.path
+			m.deleteFromDocView = true
+		} else {
+			item := m.getSelectedItem()
+			if item == nil || !item.isDoc {
+				m.statusMsg = "Select a document to delete"
+				m.statusMsgTime = time.Now()
+				return m, clearStatusAfterDelay()
+			}
+			docPath = item.path
+			m.deleteFromDocView = false
+		}
+
+		m.deletePath = docPath
+		m.mode = ModeDeleteConfirm
 		return m, nil
 	}
 

--- a/pkg/cmd/browse/view.go
+++ b/pkg/cmd/browse/view.go
@@ -51,7 +51,7 @@ func (m Model) View() string {
 
 	// Footer
 	footer := footerStyle.Render(
-		"j/k: Up/Down  h/l: Back/Forward  g/G: Top/Bottom  s: Sort  S: Clear Sort  e: Edit  yy: Copy  Y: Copy ID  ya: Copy Doc  r: Refresh  q: Quit",
+		"j/k: Up/Down  h/l: Back/Forward  g/G: Top/Bottom  s: Sort  S: Clear Sort  e: Edit  d: Delete  yy: Copy  Y: Copy ID  ya: Copy Doc  r: Refresh  q: Quit",
 	)
 
 	// Error message
@@ -128,6 +128,33 @@ func (m Model) View() string {
 	// Render sort dialog if active
 	if m.mode == ModeSortDialog {
 		dialog := m.sortDialog.View()
+		return lipgloss.Place(
+			m.width,
+			m.height,
+			lipgloss.Center,
+			lipgloss.Center,
+			dialog,
+		)
+	}
+
+	// Render delete confirmation dialog
+	if m.mode == ModeDeleteConfirm {
+		// Extract document ID from path for display
+		parts := strings.Split(m.deletePath, "/")
+		docID := m.deletePath
+		if len(parts) > 0 {
+			docID = parts[len(parts)-1]
+		}
+
+		dialogContent := lipgloss.JoinVertical(
+			lipgloss.Center,
+			errorStyle.Render("Delete document?"),
+			"",
+			docID,
+			"",
+			footerStyle.Render("y/Enter: confirm  n/Esc: cancel"),
+		)
+		dialog := deleteDialogStyle.Render(dialogContent)
 		return lipgloss.Place(
 			m.width,
 			m.height,


### PR DESCRIPTION
## Summary
- Add `d` keybinding to delete documents from the browse TUI
- Works from both collection columns (selected document) and document columns (current document)
- Shows a centered confirmation dialog with red border before deleting
- After deletion, navigates back to the parent collection and refreshes the list

## Test plan
- [x] Browse to a collection column, select a document, press `d` — confirm dialog appears
- [x] Press `n` or `Esc` to cancel — dialog dismissed, no deletion
- [x] Press `y` or `Enter` to confirm — document deleted, list refreshes
- [x] Browse into a document column, press `d` — confirm dialog appears for that document
- [x] Confirm deletion from document view — navigates back to parent collection
- [x] Press `d` on a collection item (not a document) — status message "Select a document to delete"