### PR TITLE
feat(browse): add mode system and status bar layout

### DIFF
--- a/pkg/cmd/browse/model.go
+++ b/pkg/cmd/browse/model.go
@@ -10,15 +10,37 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 )
 
-// InputMode indicates whether the user is typing a path
-type InputMode int
+// Mode represents the primary vim-style mode
+type Mode int
 
 const (
-	ModeNormal InputMode = iota
-	ModePathInput
-	ModeSortDialog
-	ModeDeleteConfirm
+	ModeNormal  Mode = iota
+	ModeVisual
+	ModeCommand
 )
+
+// Overlay represents a dialog/overlay on top of the current mode
+type Overlay int
+
+const (
+	OverlayNone Overlay = iota
+	OverlayPathInput
+	OverlaySortDialog
+	OverlayDeleteConfirm
+)
+
+func (m Mode) String() string {
+	switch m {
+	case ModeNormal:
+		return "NORMAL"
+	case ModeVisual:
+		return "VISUAL"
+	case ModeCommand:
+		return "COMMAND"
+	default:
+		return "UNKNOWN"
+	}
+}
 
 // Model represents the entire TUI state
 type Model struct {
@@ -32,8 +54,9 @@ type Model struct {
 	loading      bool
 	err          error
 
-	// Path input
-	mode      InputMode
+	// Mode system
+	mode    Mode
+	overlay Overlay
 	textInput textinput.Model
 
 	// Sort dialog

--- a/pkg/cmd/browse/navigation.go
+++ b/pkg/cmd/browse/navigation.go
@@ -141,8 +141,8 @@ func (m *Model) autoScroll() {
 	}
 
 	col := &m.columns[m.activeColumn]
-	// Match height calculation in view.go: m.height - 7 (header/path/footer/margin) - 2 (borders)
-	viewHeight := m.height - 9
+	// Match height calculation in view.go: m.height - 5 (header/statusbar/footer/error/margin) - 2 (borders)
+	viewHeight := m.height - 7
 	if viewHeight < 1 {
 		viewHeight = 10
 	}
@@ -295,7 +295,7 @@ func (m *Model) scrollDown() {
 	}
 
 	col := &m.columns[m.activeColumn]
-	viewHeight := m.height - 9
+	viewHeight := m.height - 7
 	if viewHeight < 1 {
 		viewHeight = 10
 	}
@@ -317,7 +317,7 @@ func (m *Model) scrollUp() {
 	}
 
 	col := &m.columns[m.activeColumn]
-	viewHeight := m.height - 9
+	viewHeight := m.height - 7
 	if viewHeight < 1 {
 		viewHeight = 10
 	}

--- a/pkg/cmd/browse/styles.go
+++ b/pkg/cmd/browse/styles.go
@@ -130,4 +130,28 @@ var (
 				BorderForeground(colorRed).
 				Padding(1, 2).
 				Width(50)
+
+	// Mode indicator styles
+	modeNormalStyle = lipgloss.NewStyle().
+			Bold(true).
+			Foreground(lipgloss.Color("0")).
+			Background(colorGreen).
+			Padding(0, 1)
+
+	modeVisualStyle = lipgloss.NewStyle().
+			Bold(true).
+			Foreground(lipgloss.Color("0")).
+			Background(colorYellow).
+			Padding(0, 1)
+
+	modeCommandStyle = lipgloss.NewStyle().
+				Bold(true).
+				Foreground(lipgloss.Color("0")).
+				Background(colorBlue).
+				Padding(0, 1)
+
+	// Status bar style
+	statusBarStyle = lipgloss.NewStyle().
+			Foreground(colorGray).
+			Padding(0, 1)
 )

--- a/pkg/cmd/browse/update.go
+++ b/pkg/cmd/browse/update.go
@@ -15,120 +15,40 @@ import (
 
 // Update handles all messages and updates the model
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
-	var cmd tea.Cmd
-
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
-		logDebug("KeyMsg received: %s", msg.String())
+		logDebug("KeyMsg received: %s (mode=%s, overlay=%d)", msg.String(), m.mode, m.overlay)
 
-		// Handle input mode
-		if m.mode == ModePathInput {
-			switch msg.String() {
-			case "enter":
-				// Browse to new path
-				path := strings.Trim(m.textInput.Value(), "/")
-
-				// Determine if it is a doc or collection
-				// A simple heuristic: even segments = doc, odd = collection
-				// Root (empty string) is handled as collection list
-				isDoc := false
-				if path != "" {
-					segments := strings.Split(path, "/")
-					isDoc = len(segments)%2 == 0
-				}
-
-				// Reset columns
-				m.columns = []Column{{
-					path:         path,
-					isDoc:        isDoc,
-					scrollOffset: 0,
-				}}
-				m.activeColumn = 0
-				m.mode = ModeNormal
-				m.textInput.Blur()
-				m.textInput.Reset()
-				m.loading = true
-				sortField, sortDir := m.getSortParams(path)
-				return m, fetchColumnData(m.client, path, isDoc, 0, sortField, sortDir)
-			case "esc":
-				m.mode = ModeNormal
-				m.textInput.Blur()
-				m.textInput.Reset()
-				return m, nil
-			}
-			m.textInput, cmd = m.textInput.Update(msg)
-			return m, cmd
+		// Handle overlays first (dialogs on top of any mode)
+		if m.overlay != OverlayNone {
+			return m.handleOverlay(msg)
 		}
 
-		// Handle sort dialog mode
-		if m.mode == ModeSortDialog {
-			switch msg.String() {
-			case "tab":
-				// Toggle focus between text input and list
-				if m.sortDialog.focusedComponent == 0 {
-					m.sortDialog.focusedComponent = 1
-					m.sortDialog.textInput.Blur()
-				} else {
-					m.sortDialog.focusedComponent = 0
-					m.sortDialog.textInput.Focus()
-				}
-				return m, nil
-			case "ctrl+d":
-				// Toggle direction
-				if m.sortDialog.direction == firestore.Asc {
-					m.sortDialog.direction = firestore.Desc
-				} else {
-					m.sortDialog.direction = firestore.Asc
-				}
-				return m, nil
-			case "enter":
-				// Apply sort
-				return m.applySortAndClose()
-			case "esc":
-				// Cancel
+		// Route through mode system
+		switch m.mode {
+		case ModeNormal:
+			// Global keys available in normal mode
+			if msg.String() == "ctrl+g" {
+				m.overlay = OverlayPathInput
+				m.textInput.Focus()
+				return m, textinput.Blink
+			}
+			return m.handleKeyPress(msg)
+
+		case ModeVisual:
+			if msg.String() == "esc" {
 				m.mode = ModeNormal
 				return m, nil
 			}
+			return m, nil
 
-			// Delegate to focused component
-			if m.sortDialog.focusedComponent == 0 {
-				// Text input focused
-				m.sortDialog.textInput, cmd = m.sortDialog.textInput.Update(msg)
-			} else {
-				// List focused
-				cmd = m.sortDialog.Update(msg)
-			}
-			return m, cmd
-		}
-
-		// Handle delete confirmation mode
-		if m.mode == ModeDeleteConfirm {
-			switch msg.String() {
-			case "y", "enter":
-				path := m.deletePath
-				fromDocView := m.deleteFromDocView
-				m.deletePath = ""
-				m.deleteFromDocView = false
-				m.mode = ModeNormal
-				m.loading = true
-				return m, deleteDocument(m.client, path, fromDocView)
-			case "n", "esc", "q":
-				m.deletePath = ""
-				m.deleteFromDocView = false
+		case ModeCommand:
+			if msg.String() == "esc" {
 				m.mode = ModeNormal
 				return m, nil
 			}
 			return m, nil
 		}
-
-		// Handle normal mode global keys
-		if msg.String() == "ctrl+g" {
-			m.mode = ModePathInput
-			m.textInput.Focus()
-			return m, textinput.Blink
-		}
-
-		return m.handleKeyPress(msg)
 
 	case tea.WindowSizeMsg:
 
@@ -139,7 +59,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		for i := range m.columns {
 			if m.columns[i].isDoc && m.columns[i].docContent != "" {
 				colWidth := calculateColumnWidth(m.width, len(m.columns))
-				colHeight := m.height - 6 // Account for header and footer
+				colHeight := m.height - 7 // Account for header and footer
 				vpWidth := colWidth - 4
 				vpHeight := colHeight - 10
 				// Ensure minimum viewport dimensions (at least 20x5)
@@ -176,7 +96,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// Only create viewport if we have valid dimensions
 			if m.columns[msg.columnIndex].isDoc && msg.docContent != "" && m.width > 0 && m.height > 0 {
 				colWidth := calculateColumnWidth(m.width, len(m.columns))
-				colHeight := m.height - 6
+				colHeight := m.height - 7
 				// Ensure minimum viewport dimensions (at least 20x5)
 				vpWidth := colWidth - 4
 				vpHeight := colHeight - 10
@@ -431,7 +351,7 @@ func (m Model) handleKeyPress(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 		// Initialize sort dialog with available fields
 		m.sortDialog = initSortDialog(col.availableFields)
-		m.mode = ModeSortDialog
+		m.overlay = OverlaySortDialog
 		return m, nil
 
 	case "S":
@@ -504,7 +424,95 @@ func (m Model) handleKeyPress(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 
 		m.deletePath = docPath
-		m.mode = ModeDeleteConfirm
+		m.overlay = OverlayDeleteConfirm
+		return m, nil
+	}
+
+	return m, nil
+}
+
+// handleOverlay processes keyboard input when an overlay/dialog is active
+func (m Model) handleOverlay(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	var cmd tea.Cmd
+
+	switch m.overlay {
+	case OverlayPathInput:
+		switch msg.String() {
+		case "enter":
+			path := strings.Trim(m.textInput.Value(), "/")
+			isDoc := false
+			if path != "" {
+				segments := strings.Split(path, "/")
+				isDoc = len(segments)%2 == 0
+			}
+			m.columns = []Column{{
+				path:         path,
+				isDoc:        isDoc,
+				scrollOffset: 0,
+			}}
+			m.activeColumn = 0
+			m.overlay = OverlayNone
+			m.textInput.Blur()
+			m.textInput.Reset()
+			m.loading = true
+			sortField, sortDir := m.getSortParams(path)
+			return m, fetchColumnData(m.client, path, isDoc, 0, sortField, sortDir)
+		case "esc":
+			m.overlay = OverlayNone
+			m.textInput.Blur()
+			m.textInput.Reset()
+			return m, nil
+		}
+		m.textInput, cmd = m.textInput.Update(msg)
+		return m, cmd
+
+	case OverlaySortDialog:
+		switch msg.String() {
+		case "tab":
+			if m.sortDialog.focusedComponent == 0 {
+				m.sortDialog.focusedComponent = 1
+				m.sortDialog.textInput.Blur()
+			} else {
+				m.sortDialog.focusedComponent = 0
+				m.sortDialog.textInput.Focus()
+			}
+			return m, nil
+		case "ctrl+d":
+			if m.sortDialog.direction == firestore.Asc {
+				m.sortDialog.direction = firestore.Desc
+			} else {
+				m.sortDialog.direction = firestore.Asc
+			}
+			return m, nil
+		case "enter":
+			return m.applySortAndClose()
+		case "esc":
+			m.overlay = OverlayNone
+			return m, nil
+		}
+		if m.sortDialog.focusedComponent == 0 {
+			m.sortDialog.textInput, cmd = m.sortDialog.textInput.Update(msg)
+		} else {
+			cmd = m.sortDialog.Update(msg)
+		}
+		return m, cmd
+
+	case OverlayDeleteConfirm:
+		switch msg.String() {
+		case "y", "enter":
+			path := m.deletePath
+			fromDocView := m.deleteFromDocView
+			m.deletePath = ""
+			m.deleteFromDocView = false
+			m.overlay = OverlayNone
+			m.loading = true
+			return m, deleteDocument(m.client, path, fromDocView)
+		case "n", "esc", "q":
+			m.deletePath = ""
+			m.deleteFromDocView = false
+			m.overlay = OverlayNone
+			return m, nil
+		}
 		return m, nil
 	}
 
@@ -535,7 +543,7 @@ func (m Model) applySortAndClose() (tea.Model, tea.Cmd) {
 	}
 
 	// Close dialog and refresh with sort
-	m.mode = ModeNormal
+	m.overlay = OverlayNone
 	m.loading = true
 
 	// Show status message

--- a/pkg/cmd/browse/view.go
+++ b/pkg/cmd/browse/view.go
@@ -25,17 +25,12 @@ func (m Model) View() string {
 	// Construct path string from columns
 	var pathSegments []string
 	for i, col := range m.columns {
-		// Only show path segments for the active path (up to active column)
 		if i > m.activeColumn {
 			break
 		}
-
-		// For the first column (root), we ignore empty path
 		if i == 0 && col.path == "" {
 			continue
 		}
-
-		// For other columns, extract the last segment of the path
 		parts := strings.Split(col.path, "/")
 		if len(parts) > 0 {
 			segment := parts[len(parts)-1]
@@ -44,20 +39,33 @@ func (m Model) View() string {
 			}
 		}
 	}
-
-	// Join segments with "/"
 	fullPath := "/" + strings.Join(pathSegments, "/")
-	pathView := pathStyle.Render("Path: " + fullPath)
 
-	// Footer
-	footer := footerStyle.Render(
-		"j/k: Up/Down  h/l: Back/Forward  g/G: Top/Bottom  s: Sort  S: Clear Sort  e: Edit  d: Delete  yy: Copy  Y: Copy ID  ya: Copy Doc  r: Refresh  q: Quit",
-	)
+	// Header: project ID | path | mode indicator
+	modeIndicator := modeNormalStyle.Render("[" + m.mode.String() + "]")
+	switch m.mode {
+	case ModeVisual:
+		modeIndicator = modeVisualStyle.Render("[VISUAL]")
+	case ModeCommand:
+		modeIndicator = modeCommandStyle.Render("[COMMAND]")
+	}
+
+	headerLeft := headerStyle.Render(m.projectID)
+	headerPath := pathStyle.Render(fullPath)
+	headerRight := modeIndicator
+	headerGap := strings.Repeat(" ", max(m.width-lipgloss.Width(headerLeft)-lipgloss.Width(headerPath)-lipgloss.Width(headerRight)-2, 1))
+	header := headerLeft + " " + headerPath + headerGap + headerRight
+
+	// Footer: context-sensitive hints based on mode/overlay
+	footer := footerStyle.Render(m.getFooterHints())
+
+	// Status bar (placeholder between columns and footer)
+	statusBar := m.renderStatusBar()
 
 	// Error message
-	errorMsg := ""
+	errorView := ""
 	if m.err != nil {
-		errorMsg = errorStyle.Render(fmt.Sprintf("Error: %v", m.err))
+		errorView = errorStyle.Render(fmt.Sprintf("Error: %v", m.err))
 	}
 
 	// Loading indicator
@@ -74,36 +82,23 @@ func (m Model) View() string {
 	logDebug("View: about to JoinVertical")
 	content := lipgloss.JoinVertical(
 		lipgloss.Left,
+		header,
 		columnsView,
-		pathView,
-		errorMsg,
+		statusBar,
+		errorView,
 		loadingMsg,
 		footer,
 	)
 	logDebug("View: JoinVertical successful, contentLen=%d", len(content))
 
-	// Overlay input dialog if in input mode
-	if m.mode == ModePathInput {
-		// Create dialog content
+	// Overlay dialogs
+	if m.overlay == OverlayPathInput {
 		dialogContent := lipgloss.JoinVertical(
 			lipgloss.Center,
 			"Enter Firestore Path:",
 			m.textInput.View(),
 		)
 		dialog := inputDialogStyle.Render(dialogContent)
-
-		// Center dialog over existing content
-		// For simplicity in Bubble Tea without advanced layering, we can just replace the content
-		// or use lipgloss.Place to overlay if we had a full screen canvas,
-		// but standard string joining doesn't do z-index.
-		// However, lipgloss.Place can position a string within a given dimension.
-		// We can try to overlay it on top of the 'content' string if we treat 'content' as the background?
-		// But lipgloss.Place works on a whitespace background.
-		// A simpler way for a TUI modal:
-		// Just render the dialog in the middle of the screen size, replacing the middle part?
-		// Or render it OVER the content using lipgloss.Place.
-
-		// Let's use lipgloss.Place to center the dialog in the full terminal size
 		return lipgloss.Place(
 			m.width,
 			m.height,
@@ -111,22 +106,11 @@ func (m Model) View() string {
 			lipgloss.Center,
 			dialog,
 			lipgloss.WithWhitespaceChars(" "),
-			lipgloss.WithWhitespaceForeground(
-				colorGray,
-			), // Dim background? No, this replaces background
+			lipgloss.WithWhitespaceForeground(colorGray),
 		)
-		// Wait, this REPLACES the entire view with the placed dialog on a blank background.
-		// To show the underlying content dimmed, we'd need to manually composite.
-		// For now, replacing the view with the dialog is acceptable for a modal,
-		// but ideally we want to see the background.
-		// Given the constraints, let's just return the dialog centered on a blank screen for now to ensure it works.
-		// Or better: render the main view, then if we could overlay...
-		// But string overlay is hard.
-		// Let's just return the dialog centered. It's a "modal" mode.
 	}
 
-	// Render sort dialog if active
-	if m.mode == ModeSortDialog {
+	if m.overlay == OverlaySortDialog {
 		dialog := m.sortDialog.View()
 		return lipgloss.Place(
 			m.width,
@@ -137,9 +121,7 @@ func (m Model) View() string {
 		)
 	}
 
-	// Render delete confirmation dialog
-	if m.mode == ModeDeleteConfirm {
-		// Extract document ID from path for display
+	if m.overlay == OverlayDeleteConfirm {
 		parts := strings.Split(m.deletePath, "/")
 		docID := m.deletePath
 		if len(parts) > 0 {
@@ -377,12 +359,14 @@ func (m Model) renderColumn(col Column, width int, isActive bool) string {
 
 	// Calculate available height
 	// m.height includes:
-	// - path (1)
+	// - header (1)
+	// - status bar (1)
 	// - footer (1)
+	// - error/loading (1)
 	// - some margin (1)
-	// Total overhead = 4
+	// Total overhead = 5
 	// We also need to account for the border (top + bottom = 2)
-	height := m.height - 4 - 2
+	height := m.height - 5 - 2
 	if height < 1 {
 		height = 10 // Minimum height
 	}
@@ -626,4 +610,31 @@ func (m Model) renderColumn(col Column, width int, isActive bool) string {
 	}
 
 	return result
+}
+
+// getFooterHints returns context-sensitive keybinding hints
+func (m Model) getFooterHints() string {
+	if m.overlay == OverlaySortDialog {
+		return "Tab: Switch field  Ctrl+d: Toggle direction  Enter: Apply  Esc: Cancel"
+	}
+	if m.overlay == OverlayDeleteConfirm {
+		return "y/Enter: Confirm  n/Esc: Cancel"
+	}
+	if m.overlay == OverlayPathInput {
+		return "Enter: Navigate  Esc: Cancel"
+	}
+
+	switch m.mode {
+	case ModeVisual:
+		return "Esc: Normal mode"
+	case ModeCommand:
+		return "Esc: Normal mode"
+	default:
+		return "j/k: Up/Down  h/l: Back/Forward  g/G: Top/Bottom  s: Sort  e: Edit  d: Delete  yy: Copy  Y: Copy ID  r: Refresh  Ctrl+g: Goto  q: Quit"
+	}
+}
+
+// renderStatusBar renders the status bar area between columns and footer
+func (m Model) renderStatusBar() string {
+	return statusBarStyle.Render("")
 }


### PR DESCRIPTION
## Summary
- Replace ad-hoc `InputMode` enum with centralized `Mode` (Normal/Visual/Command) + `Overlay` (PathInput/SortDialog/DeleteConfirm) state machine
- Add header line with project ID, Firestore path, and `[NORMAL]` mode indicator
- Add context-sensitive footer hints that change based on active mode/overlay
- Add status bar placeholder between columns and footer for future filter/sort/page state
- Refactor key dispatch in `Update` to route through mode system via `handleOverlay()` and mode switch

## Test plan
- [ ] Verify `go build ./...` and `go vet ./...` pass
- [ ] Launch browse TUI and confirm header shows project ID, path, and `[NORMAL]` indicator
- [ ] Verify j/k/h/l/g/G navigation works as before
- [ ] Verify sort dialog (s) opens and functions correctly
- [ ] Verify delete confirmation (d) opens and functions correctly
- [ ] Verify Ctrl+g path input opens and functions correctly
- [ ] Verify Esc returns to Normal mode from any overlay
- [ ] Verify footer hints change contextually for sort/delete/path input overlays
- [ ] Verify q quits the application

Closes #19