### PR TITLE
feat(browse): add command mode with :help, :goto, :refresh, :sort

### DIFF
--- a/pkg/cmd/browse/command.go
+++ b/pkg/cmd/browse/command.go
@@ -1,0 +1,202 @@
+package browse
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"cloud.google.com/go/firestore"
+)
+
+type CommandHandler func(m *Model, args []string) (statusMsg string, err error)
+
+type Command struct {
+	Name        string
+	Description string
+	Usage       string
+	Handler     CommandHandler
+}
+
+type CommandRegistry struct {
+	commands map[string]Command
+}
+
+func NewCommandRegistry() *CommandRegistry {
+	return &CommandRegistry{
+		commands: make(map[string]Command),
+	}
+}
+
+func (r *CommandRegistry) Register(cmd Command) {
+	r.commands[cmd.Name] = cmd
+}
+
+func (r *CommandRegistry) Get(name string) (Command, bool) {
+	cmd, ok := r.commands[name]
+	return cmd, ok
+}
+
+func (r *CommandRegistry) Complete(prefix string) []string {
+	var matches []string
+	for name := range r.commands {
+		if strings.HasPrefix(name, prefix) {
+			matches = append(matches, name)
+		}
+	}
+	sort.Strings(matches)
+	return matches
+}
+
+func (r *CommandRegistry) All() []Command {
+	var cmds []Command
+	for _, cmd := range r.commands {
+		cmds = append(cmds, cmd)
+	}
+	sort.Slice(cmds, func(i, j int) bool {
+		return cmds[i].Name < cmds[j].Name
+	})
+	return cmds
+}
+
+// ParseCommand splits input into command name and arguments.
+func ParseCommand(input string) (name string, args []string) {
+	input = strings.TrimSpace(input)
+	if input == "" {
+		return "", nil
+	}
+	parts := strings.Fields(input)
+	return parts[0], parts[1:]
+}
+
+// pendingFetchCmd stores the parameters for a deferred fetch operation
+type pendingFetchCmd struct {
+	path      string
+	isDoc     bool
+	colIndex  int
+	sortField string
+	sortDir   firestore.Direction
+}
+
+func initCommandRegistry() *CommandRegistry {
+	r := NewCommandRegistry()
+
+	r.Register(Command{
+		Name:        "help",
+		Description: "List all available commands",
+		Usage:       ":help",
+		Handler:     cmdHelp,
+	})
+
+	r.Register(Command{
+		Name:        "goto",
+		Description: "Navigate to a Firestore path",
+		Usage:       ":goto <path>",
+		Handler:     cmdGoto,
+	})
+
+	r.Register(Command{
+		Name:        "refresh",
+		Description: "Refresh the current column",
+		Usage:       ":refresh",
+		Handler:     cmdRefresh,
+	})
+
+	r.Register(Command{
+		Name:        "sort",
+		Description: "Sort collection by field",
+		Usage:       ":sort <field> [asc|desc]",
+		Handler:     cmdSort,
+	})
+
+	return r
+}
+
+func cmdHelp(m *Model, args []string) (string, error) {
+	var lines []string
+	for _, cmd := range m.commandRegistry.All() {
+		lines = append(lines, fmt.Sprintf("  %-20s %s", cmd.Usage, cmd.Description))
+	}
+	return "Commands:\n" + strings.Join(lines, "\n"), nil
+}
+
+func cmdGoto(m *Model, args []string) (string, error) {
+	if len(args) == 0 {
+		return "", fmt.Errorf("usage: :goto <path>")
+	}
+
+	path := strings.Trim(strings.Join(args, " "), "/")
+	isDoc := false
+	if path != "" {
+		segments := strings.Split(path, "/")
+		isDoc = len(segments)%2 == 0
+	}
+
+	m.columns = []Column{{
+		path:         path,
+		isDoc:        isDoc,
+		scrollOffset: 0,
+	}}
+	m.activeColumn = 0
+	m.loading = true
+
+	sortField, sortDir := m.getSortParams(path)
+	m.pendingFetch = &pendingFetchCmd{path: path, isDoc: isDoc, colIndex: 0, sortField: sortField, sortDir: sortDir}
+
+	return fmt.Sprintf("Navigating to /%s", path), nil
+}
+
+func cmdRefresh(m *Model, args []string) (string, error) {
+	if m.activeColumn >= len(m.columns) {
+		return "", fmt.Errorf("no column to refresh")
+	}
+
+	col := m.columns[m.activeColumn]
+	m.loading = true
+
+	sortField, sortDir := m.getSortParams(col.path)
+	m.pendingFetch = &pendingFetchCmd{path: col.path, isDoc: col.isDoc, colIndex: m.activeColumn, sortField: sortField, sortDir: sortDir}
+
+	return "Refreshing...", nil
+}
+
+func cmdSort(m *Model, args []string) (string, error) {
+	if len(args) == 0 {
+		return "", fmt.Errorf("usage: :sort <field> [asc|desc]")
+	}
+
+	if m.activeColumn >= len(m.columns) {
+		return "", fmt.Errorf("no column to sort")
+	}
+
+	col := m.columns[m.activeColumn]
+	if col.isDoc {
+		return "", fmt.Errorf("can only sort collections, not documents")
+	}
+
+	field := args[0]
+	dir := firestore.Asc
+	if len(args) > 1 {
+		switch strings.ToLower(args[1]) {
+		case "desc", "descending":
+			dir = firestore.Desc
+		case "asc", "ascending":
+			dir = firestore.Asc
+		default:
+			return "", fmt.Errorf("invalid direction %q, use asc or desc", args[1])
+		}
+	}
+
+	m.sortState[col.path] = sortStateEntry{
+		Field:     field,
+		Direction: dir,
+	}
+
+	m.loading = true
+	m.pendingFetch = &pendingFetchCmd{path: col.path, isDoc: col.isDoc, colIndex: m.activeColumn, sortField: field, sortDir: dir}
+
+	dirStr := "Ascending"
+	if dir == firestore.Desc {
+		dirStr = "Descending"
+	}
+	return fmt.Sprintf("Sorted by %s (%s)", field, dirStr), nil
+}

--- a/pkg/cmd/browse/command_test.go
+++ b/pkg/cmd/browse/command_test.go
@@ -1,0 +1,124 @@
+package browse
+
+import (
+	"testing"
+)
+
+func TestParseCommand(t *testing.T) {
+	tests := []struct {
+		input    string
+		wantName string
+		wantArgs []string
+	}{
+		{"", "", nil},
+		{"help", "help", nil},
+		{"goto users", "goto", []string{"users"}},
+		{"sort createdAt desc", "sort", []string{"createdAt", "desc"}},
+		{"  goto  users/abc123  ", "goto", []string{"users/abc123"}},
+		{"refresh", "refresh", nil},
+	}
+
+	for _, tt := range tests {
+		name, args := ParseCommand(tt.input)
+		if name != tt.wantName {
+			t.Errorf("ParseCommand(%q) name = %q, want %q", tt.input, name, tt.wantName)
+		}
+		if len(args) != len(tt.wantArgs) {
+			t.Errorf("ParseCommand(%q) args len = %d, want %d", tt.input, len(args), len(tt.wantArgs))
+			continue
+		}
+		for i := range args {
+			if args[i] != tt.wantArgs[i] {
+				t.Errorf("ParseCommand(%q) args[%d] = %q, want %q", tt.input, i, args[i], tt.wantArgs[i])
+			}
+		}
+	}
+}
+
+func TestCommandRegistryComplete(t *testing.T) {
+	r := NewCommandRegistry()
+	r.Register(Command{Name: "help", Description: "help desc"})
+	r.Register(Command{Name: "goto", Description: "goto desc"})
+	r.Register(Command{Name: "get", Description: "get desc"})
+	r.Register(Command{Name: "sort", Description: "sort desc"})
+	r.Register(Command{Name: "refresh", Description: "refresh desc"})
+
+	tests := []struct {
+		prefix string
+		want   []string
+	}{
+		{"g", []string{"get", "goto"}},
+		{"go", []string{"goto"}},
+		{"s", []string{"sort"}},
+		{"r", []string{"refresh"}},
+		{"h", []string{"help"}},
+		{"x", nil},
+		{"", []string{"get", "goto", "help", "refresh", "sort"}},
+	}
+
+	for _, tt := range tests {
+		got := r.Complete(tt.prefix)
+		if len(got) != len(tt.want) {
+			t.Errorf("Complete(%q) = %v, want %v", tt.prefix, got, tt.want)
+			continue
+		}
+		for i := range got {
+			if got[i] != tt.want[i] {
+				t.Errorf("Complete(%q)[%d] = %q, want %q", tt.prefix, i, got[i], tt.want[i])
+			}
+		}
+	}
+}
+
+func TestCommandRegistryGet(t *testing.T) {
+	r := NewCommandRegistry()
+	r.Register(Command{Name: "help", Description: "help desc"})
+
+	cmd, ok := r.Get("help")
+	if !ok {
+		t.Fatal("expected to find 'help' command")
+	}
+	if cmd.Name != "help" {
+		t.Errorf("cmd.Name = %q, want %q", cmd.Name, "help")
+	}
+
+	_, ok = r.Get("unknown")
+	if ok {
+		t.Error("expected not to find 'unknown' command")
+	}
+}
+
+func TestCommandRegistryAll(t *testing.T) {
+	r := NewCommandRegistry()
+	r.Register(Command{Name: "zebra"})
+	r.Register(Command{Name: "alpha"})
+	r.Register(Command{Name: "middle"})
+
+	all := r.All()
+	if len(all) != 3 {
+		t.Fatalf("All() returned %d commands, want 3", len(all))
+	}
+	if all[0].Name != "alpha" || all[1].Name != "middle" || all[2].Name != "zebra" {
+		t.Errorf("All() not sorted: got %v", []string{all[0].Name, all[1].Name, all[2].Name})
+	}
+}
+
+func TestLongestCommonPrefix(t *testing.T) {
+	tests := []struct {
+		input []string
+		want  string
+	}{
+		{nil, ""},
+		{[]string{"goto"}, "goto"},
+		{[]string{"goto", "get"}, "g"},
+		{[]string{"sort", "sort"}, "sort"},
+		{[]string{"abc", "xyz"}, ""},
+	}
+
+	for _, tt := range tests {
+		got := longestCommonPrefix(tt.input)
+		if got != tt.want {
+			t.Errorf("longestCommonPrefix(%v) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}

--- a/pkg/cmd/browse/model.go
+++ b/pkg/cmd/browse/model.go
@@ -59,6 +59,12 @@ type Model struct {
 	overlay Overlay
 	textInput textinput.Model
 
+	// Command mode
+	commandRegistry *CommandRegistry
+	commandInput    textinput.Model
+	commandResult   string
+	pendingFetch    *pendingFetchCmd
+
 	// Sort dialog
 	sortDialog sortDialogModel
 	sortState  map[string]sortStateEntry // Path -> sort state

--- a/pkg/cmd/browse/root.go
+++ b/pkg/cmd/browse/root.go
@@ -82,20 +82,29 @@ Examples:
 			ti.CharLimit = 150
 			ti.Width = 50
 
+			// Initialize command input
+			ci := textinput.New()
+			ci.Placeholder = ""
+			ci.CharLimit = 200
+			ci.Width = 50
+			ci.Prompt = ":"
+
 			// Initialize model
 			m := Model{
-				client:       client,
-				ctx:          ctx,
-				projectID:    projectID,
-				columns:      []Column{{path: startPath, isDoc: isDoc}},
-				activeColumn: 0,
-				width:        0,
-				height:       0,
-				loading:      true,
-				err:          nil,
-				textInput:    ti,
-				sortState:    make(map[string]sortStateEntry),
-				mode:         ModeNormal,
+				client:          client,
+				ctx:             ctx,
+				projectID:       projectID,
+				columns:         []Column{{path: startPath, isDoc: isDoc}},
+				activeColumn:    0,
+				width:           0,
+				height:          0,
+				loading:         true,
+				err:             nil,
+				textInput:       ti,
+				sortState:       make(map[string]sortStateEntry),
+				mode:            ModeNormal,
+				commandRegistry: initCommandRegistry(),
+				commandInput:    ci,
 			}
 
 			// Run TUI

--- a/pkg/cmd/browse/update.go
+++ b/pkg/cmd/browse/update.go
@@ -33,6 +33,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.textInput.Focus()
 				return m, textinput.Blink
 			}
+			// Enter command mode
+			if msg.String() == ":" {
+				m.mode = ModeCommand
+				m.commandInput.Reset()
+				m.commandInput.Focus()
+				m.commandResult = ""
+				return m, textinput.Blink
+			}
 			return m.handleKeyPress(msg)
 
 		case ModeVisual:
@@ -43,11 +51,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 
 		case ModeCommand:
-			if msg.String() == "esc" {
-				m.mode = ModeNormal
-				return m, nil
-			}
-			return m, nil
+			return m.handleCommandMode(msg)
 		}
 
 	case tea.WindowSizeMsg:
@@ -558,4 +562,95 @@ func (m Model) applySortAndClose() (tea.Model, tea.Cmd) {
 		fetchColumnData(m.client, col.path, col.isDoc, m.activeColumn, field, m.sortDialog.direction),
 		clearStatusAfterDelay(),
 	)
+}
+
+// handleCommandMode processes input in command mode
+func (m Model) handleCommandMode(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "esc":
+		m.mode = ModeNormal
+		m.commandInput.Blur()
+		m.commandInput.Reset()
+		m.commandResult = ""
+		return m, nil
+
+	case "enter":
+		input := m.commandInput.Value()
+		m.mode = ModeNormal
+		m.commandInput.Blur()
+		m.commandInput.Reset()
+
+		name, args := ParseCommand(input)
+		if name == "" {
+			return m, nil
+		}
+
+		cmd, ok := m.commandRegistry.Get(name)
+		if !ok {
+			m.statusMsg = fmt.Sprintf("Unknown command: %s", name)
+			m.statusMsgTime = time.Now()
+			return m, clearStatusAfterDelay()
+		}
+
+		statusText, err := cmd.Handler(&m, args)
+		if err != nil {
+			m.statusMsg = fmt.Sprintf("Error: %s", err)
+			m.statusMsgTime = time.Now()
+			return m, clearStatusAfterDelay()
+		}
+
+		if statusText != "" {
+			m.statusMsg = statusText
+			m.statusMsgTime = time.Now()
+		}
+
+		// Check if the handler set a pending fetch
+		if m.pendingFetch != nil {
+			pf := m.pendingFetch
+			m.pendingFetch = nil
+			return m, tea.Batch(
+				fetchColumnData(m.client, pf.path, pf.isDoc, pf.colIndex, pf.sortField, pf.sortDir),
+				clearStatusAfterDelay(),
+			)
+		}
+
+		return m, clearStatusAfterDelay()
+
+	case "tab":
+		// Tab completion
+		input := m.commandInput.Value()
+		name, _ := ParseCommand(input)
+		matches := m.commandRegistry.Complete(name)
+		if len(matches) == 1 {
+			m.commandInput.SetValue(matches[0] + " ")
+			m.commandInput.CursorEnd()
+		} else if len(matches) > 1 {
+			// Find common prefix
+			prefix := longestCommonPrefix(matches)
+			if len(prefix) > len(name) {
+				m.commandInput.SetValue(prefix)
+				m.commandInput.CursorEnd()
+			}
+			m.commandResult = strings.Join(matches, "  ")
+		}
+		return m, nil
+	}
+
+	var cmd tea.Cmd
+	m.commandInput, cmd = m.commandInput.Update(msg)
+	m.commandResult = ""
+	return m, cmd
+}
+
+func longestCommonPrefix(strs []string) string {
+	if len(strs) == 0 {
+		return ""
+	}
+	prefix := strs[0]
+	for _, s := range strs[1:] {
+		for len(prefix) > 0 && !strings.HasPrefix(s, prefix) {
+			prefix = prefix[:len(prefix)-1]
+		}
+	}
+	return prefix
 }

--- a/pkg/cmd/browse/view.go
+++ b/pkg/cmd/browse/view.go
@@ -56,8 +56,21 @@ func (m Model) View() string {
 	headerGap := strings.Repeat(" ", max(m.width-lipgloss.Width(headerLeft)-lipgloss.Width(headerPath)-lipgloss.Width(headerRight)-2, 1))
 	header := headerLeft + " " + headerPath + headerGap + headerRight
 
-	// Footer: context-sensitive hints based on mode/overlay
-	footer := footerStyle.Render(m.getFooterHints())
+	// Footer: context-sensitive hints or command prompt
+	var footer string
+	if m.mode == ModeCommand {
+		commandLine := m.commandInput.View()
+		if m.commandResult != "" {
+			footer = lipgloss.JoinVertical(lipgloss.Left,
+				footerStyle.Render(m.commandResult),
+				commandLine,
+			)
+		} else {
+			footer = commandLine
+		}
+	} else {
+		footer = footerStyle.Render(m.getFooterHints())
+	}
 
 	// Status bar (placeholder between columns and footer)
 	statusBar := m.renderStatusBar()


### PR DESCRIPTION
## Summary
- Add Command mode activated by `:` in Normal mode with prompt in footer
- Implement command engine with registry, parser, tab-completion, and handler dispatch
- Ship `:help` (list commands), `:goto <path>` (navigate), `:refresh` (reload), `:sort <field> [asc|desc]` (sort collection)
- Ctrl+g remains as alias for `:goto`
- Mode indicator changes to `[COMMAND]` in header when active
- Unit tests cover parsing, tab-completion ordering, unknown commands, and registry operations

## Test plan
- [ ] Press `:` to enter command mode — prompt appears in footer with `[COMMAND]` indicator
- [ ] Tab-completion suggests matching commands
- [ ] `:help` shows all registered commands
- [ ] `:goto users` navigates to users collection
- [ ] `:goto users/abc123` navigates to a document
- [ ] `:refresh` reloads current column data
- [ ] `:sort createdAt desc` sorts collection descending
- [ ] `:sort createdAt` defaults to ascending
- [ ] Unknown command shows error in status bar
- [ ] Esc cancels command mode
- [ ] Ctrl+g still works as shortcut for goto
- [ ] All unit tests pass

Closes #20