### PR TITLE
feat(browse): add client-side live filter on /

### DIFF
--- a/pkg/cmd/browse/filter.go
+++ b/pkg/cmd/browse/filter.go
@@ -1,0 +1,56 @@
+package browse
+
+import (
+	"strings"
+)
+
+// getEffectiveSections returns the sections for display, applying any active filter.
+func (m *Model) getEffectiveSections(col Column) []Section {
+	if m.filterPattern == "" {
+		return col.sections
+	}
+	// Only filter the active column
+	if m.activeColumn < len(m.columns) && &m.columns[m.activeColumn] != nil && col.path == m.columns[m.activeColumn].path {
+		return FilterSections(col.sections, m.filterPattern)
+	}
+	return col.sections
+}
+
+// FilterItems returns only items whose display ID contains the pattern (case-insensitive).
+// Returns all items if pattern is empty.
+func FilterItems(items []ListItem, pattern string) []ListItem {
+	if pattern == "" {
+		return items
+	}
+	lower := strings.ToLower(pattern)
+	var result []ListItem
+	for _, item := range items {
+		if strings.Contains(strings.ToLower(item.id), lower) {
+			result = append(result, item)
+		}
+	}
+	return result
+}
+
+// FilterSections returns sections with items filtered by pattern.
+// Only non-data sections (Documents, Subcollections) are filtered.
+// Data sections are returned as-is since they represent document fields.
+func FilterSections(sections []Section, pattern string) []Section {
+	if pattern == "" {
+		return sections
+	}
+	var result []Section
+	for _, s := range sections {
+		if s.title == "Data" || s.title == "Metadata" {
+			result = append(result, s)
+			continue
+		}
+		filtered := FilterItems(s.items, pattern)
+		result = append(result, Section{
+			title:  s.title,
+			items:  filtered,
+			hidden: len(filtered) == 0,
+		})
+	}
+	return result
+}

--- a/pkg/cmd/browse/filter_test.go
+++ b/pkg/cmd/browse/filter_test.go
@@ -1,0 +1,119 @@
+package browse
+
+import (
+	"testing"
+)
+
+func TestFilterItems(t *testing.T) {
+	items := []ListItem{
+		{id: "users"},
+		{id: "orders"},
+		{id: "user-profiles"},
+		{id: "Products"},
+		{id: "ADMIN_USERS"},
+	}
+
+	tests := []struct {
+		pattern string
+		want    []string
+	}{
+		{"", []string{"users", "orders", "user-profiles", "Products", "ADMIN_USERS"}},
+		{"user", []string{"users", "user-profiles", "ADMIN_USERS"}},
+		{"USER", []string{"users", "user-profiles", "ADMIN_USERS"}},
+		{"prod", []string{"Products"}},
+		{"order", []string{"orders"}},
+		{"xyz", nil},
+		{"admin", []string{"ADMIN_USERS"}},
+	}
+
+	for _, tt := range tests {
+		got := FilterItems(items, tt.pattern)
+		gotIDs := make([]string, len(got))
+		for i, item := range got {
+			gotIDs[i] = item.id
+		}
+		if len(got) != len(tt.want) {
+			t.Errorf("FilterItems(%q) = %v, want %v", tt.pattern, gotIDs, tt.want)
+			continue
+		}
+		for i := range got {
+			if got[i].id != tt.want[i] {
+				t.Errorf("FilterItems(%q)[%d] = %q, want %q", tt.pattern, i, got[i].id, tt.want[i])
+			}
+		}
+	}
+}
+
+func TestFilterSections(t *testing.T) {
+	sections := []Section{
+		{
+			title: "Documents",
+			items: []ListItem{
+				{id: "doc1"},
+				{id: "doc2"},
+				{id: "other"},
+			},
+		},
+		{
+			title: "Subcollections",
+			items: []ListItem{
+				{id: "sub-doc"},
+				{id: "archive"},
+			},
+		},
+		{
+			title: "Data",
+			items: []ListItem{
+				{id: "field1"},
+			},
+		},
+	}
+
+	filtered := FilterSections(sections, "doc")
+	if len(filtered) != 3 {
+		t.Fatalf("FilterSections returned %d sections, want 3", len(filtered))
+	}
+
+	// Documents section should be filtered
+	if len(filtered[0].items) != 2 {
+		t.Errorf("Documents section has %d items, want 2", len(filtered[0].items))
+	}
+
+	// Subcollections should be filtered
+	if len(filtered[1].items) != 1 {
+		t.Errorf("Subcollections section has %d items, want 1", len(filtered[1].items))
+	}
+	if filtered[1].items[0].id != "sub-doc" {
+		t.Errorf("Subcollections item = %q, want %q", filtered[1].items[0].id, "sub-doc")
+	}
+
+	// Data section should not be filtered
+	if len(filtered[2].items) != 1 {
+		t.Errorf("Data section has %d items, want 1", len(filtered[2].items))
+	}
+}
+
+func TestFilterSectionsEmpty(t *testing.T) {
+	sections := []Section{
+		{title: "Documents", items: []ListItem{{id: "abc"}}},
+	}
+
+	filtered := FilterSections(sections, "")
+	if len(filtered[0].items) != 1 {
+		t.Error("empty pattern should return all items")
+	}
+}
+
+func TestFilterSectionsNoMatch(t *testing.T) {
+	sections := []Section{
+		{title: "Documents", items: []ListItem{{id: "abc"}}},
+	}
+
+	filtered := FilterSections(sections, "xyz")
+	if !filtered[0].hidden {
+		t.Error("section with no matches should be hidden")
+	}
+	if len(filtered[0].items) != 0 {
+		t.Errorf("section with no matches should have 0 items, got %d", len(filtered[0].items))
+	}
+}

--- a/pkg/cmd/browse/model.go
+++ b/pkg/cmd/browse/model.go
@@ -27,6 +27,7 @@ const (
 	OverlayPathInput
 	OverlaySortDialog
 	OverlayDeleteConfirm
+	OverlayFilter
 )
 
 func (m Mode) String() string {
@@ -78,6 +79,11 @@ type Model struct {
 	// Delete confirmation
 	deletePath        string // Path of document pending deletion
 	deleteFromDocView bool   // Whether delete was initiated from a document column
+
+	// Filter
+	filterInput   textinput.Model
+	filterActive  bool
+	filterPattern string
 }
 
 // sortStateEntry stores sort configuration for a collection path

--- a/pkg/cmd/browse/navigation.go
+++ b/pkg/cmd/browse/navigation.go
@@ -51,9 +51,10 @@ func (m *Model) getSelectedItem() *ListItem {
 	}
 
 	col := &m.columns[m.activeColumn]
+	sections := m.getEffectiveSections(*col)
 	itemIndex := 0
 
-	for _, section := range col.sections {
+	for _, section := range sections {
 		if section.hidden {
 			continue
 		}
@@ -87,11 +88,11 @@ func (m *Model) getSelectedItem() *ListItem {
 	return nil
 }
 
-// getAllItems returns all visible items from a column (flattened from sections)
-// Updated to handle tree expansion
-func getAllItemsCount(col Column) int {
+// getAllItemsCount returns count of visible items in a column (with filter applied)
+func (m *Model) getAllItemsCount(col Column) int {
+	sections := m.getEffectiveSections(col)
 	count := 0
-	for _, section := range col.sections {
+	for _, section := range sections {
 		if section.hidden {
 			continue
 		}
@@ -114,7 +115,7 @@ func (m *Model) moveCursor(delta int) {
 	}
 
 	col := &m.columns[m.activeColumn]
-	totalItems := getAllItemsCount(*col)
+	totalItems := m.getAllItemsCount(*col)
 	if totalItems == 0 {
 		return
 	}
@@ -161,7 +162,8 @@ func (m *Model) autoScroll() {
 	itemIndex := 0
 	foundCursor := false
 
-	for _, section := range col.sections {
+	sections := m.getEffectiveSections(*col)
+	for _, section := range sections {
 		if section.hidden {
 			continue
 		}
@@ -281,7 +283,7 @@ func (m *Model) jumpToBottom() {
 	}
 
 	col := &m.columns[m.activeColumn]
-	count := getAllItemsCount(*col)
+	count := m.getAllItemsCount(*col)
 	if count > 0 {
 		col.cursor = count - 1
 		m.autoScroll() // Scroll to show bottom item

--- a/pkg/cmd/browse/root.go
+++ b/pkg/cmd/browse/root.go
@@ -89,6 +89,13 @@ Examples:
 			ci.Width = 50
 			ci.Prompt = ":"
 
+			// Initialize filter input
+			fi := textinput.New()
+			fi.Placeholder = ""
+			fi.CharLimit = 100
+			fi.Width = 50
+			fi.Prompt = "/"
+
 			// Initialize model
 			m := Model{
 				client:          client,
@@ -105,6 +112,7 @@ Examples:
 				mode:            ModeNormal,
 				commandRegistry: initCommandRegistry(),
 				commandInput:    ci,
+				filterInput:     fi,
 			}
 
 			// Run TUI

--- a/pkg/cmd/browse/update.go
+++ b/pkg/cmd/browse/update.go
@@ -33,6 +33,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.textInput.Focus()
 				return m, textinput.Blink
 			}
+			// Enter filter mode
+			if msg.String() == "/" {
+				m.overlay = OverlayFilter
+				m.filterInput.Reset()
+				m.filterInput.Focus()
+				return m, textinput.Blink
+			}
 			// Enter command mode
 			if msg.String() == ":" {
 				m.mode = ModeCommand
@@ -518,6 +525,40 @@ func (m Model) handleOverlay(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		return m, nil
+
+	case OverlayFilter:
+		switch msg.String() {
+		case "esc":
+			m.overlay = OverlayNone
+			m.filterInput.Blur()
+			m.filterInput.Reset()
+			m.filterActive = false
+			m.filterPattern = ""
+			if m.activeColumn < len(m.columns) {
+				m.columns[m.activeColumn].cursor = 0
+				m.columns[m.activeColumn].scrollOffset = 0
+			}
+			return m, nil
+		case "enter":
+			m.overlay = OverlayNone
+			m.filterInput.Blur()
+			pattern := m.filterInput.Value()
+			if pattern != "" {
+				m.filterActive = true
+				m.filterPattern = pattern
+			} else {
+				m.filterActive = false
+				m.filterPattern = ""
+			}
+			return m, nil
+		}
+		m.filterInput, cmd = m.filterInput.Update(msg)
+		m.filterPattern = m.filterInput.Value()
+		if m.activeColumn < len(m.columns) {
+			m.columns[m.activeColumn].cursor = 0
+			m.columns[m.activeColumn].scrollOffset = 0
+		}
+		return m, cmd
 	}
 
 	return m, nil

--- a/pkg/cmd/browse/view.go
+++ b/pkg/cmd/browse/view.go
@@ -56,7 +56,7 @@ func (m Model) View() string {
 	headerGap := strings.Repeat(" ", max(m.width-lipgloss.Width(headerLeft)-lipgloss.Width(headerPath)-lipgloss.Width(headerRight)-2, 1))
 	header := headerLeft + " " + headerPath + headerGap + headerRight
 
-	// Footer: context-sensitive hints or command prompt
+	// Footer: context-sensitive hints, command prompt, or filter input
 	var footer string
 	if m.mode == ModeCommand {
 		commandLine := m.commandInput.View()
@@ -68,6 +68,8 @@ func (m Model) View() string {
 		} else {
 			footer = commandLine
 		}
+	} else if m.overlay == OverlayFilter {
+		footer = m.filterInput.View()
 	} else {
 		footer = footerStyle.Render(m.getFooterHints())
 	}
@@ -388,13 +390,16 @@ func (m Model) renderColumn(col Column, width int, isActive bool) string {
 	// Width - Border(2) - Padding(2) = Width - 4
 	innerWidth := max(width-4, 1)
 
+	// Apply filter to sections for active column
+	sections := m.getEffectiveSections(col)
+
 	logDebug(
 		"renderColumn: width=%d, innerWidth=%d, height=%d, isActive=%v, sections=%d",
 		width,
 		innerWidth,
 		height,
 		isActive,
-		len(col.sections),
+		len(sections),
 	)
 
 	var content strings.Builder
@@ -405,7 +410,7 @@ func (m Model) renderColumn(col Column, width int, isActive bool) string {
 	wrapper := lipgloss.NewStyle().Width(innerWidth)
 
 	// Render sections
-	for _, section := range col.sections {
+	for _, section := range sections {
 		if section.hidden {
 			continue
 		}
@@ -483,7 +488,7 @@ func (m Model) renderColumn(col Column, width int, isActive bool) string {
 	// If this is a document column, render document content (RAW JSON fallback/debug)
 	// We only show this if we DON'T have a Data section (which we should always have now)
 	hasDataSection := false
-	for _, s := range col.sections {
+	for _, s := range sections {
 		if s.title == "Data" {
 			hasDataSection = true
 			break
@@ -636,6 +641,9 @@ func (m Model) getFooterHints() string {
 	if m.overlay == OverlayPathInput {
 		return "Enter: Navigate  Esc: Cancel"
 	}
+	if m.overlay == OverlayFilter {
+		return "Enter: Confirm filter  Esc: Clear and cancel"
+	}
 
 	switch m.mode {
 	case ModeVisual:
@@ -643,11 +651,14 @@ func (m Model) getFooterHints() string {
 	case ModeCommand:
 		return "Esc: Normal mode"
 	default:
-		return "j/k: Up/Down  h/l: Back/Forward  g/G: Top/Bottom  s: Sort  e: Edit  d: Delete  yy: Copy  Y: Copy ID  r: Refresh  Ctrl+g: Goto  q: Quit"
+		return "j/k: Up/Down  h/l: Back/Forward  g/G: Top/Bottom  /: Filter  s: Sort  e: Edit  d: Delete  yy: Copy  :: Command  q: Quit"
 	}
 }
 
 // renderStatusBar renders the status bar area between columns and footer
 func (m Model) renderStatusBar() string {
+	if m.filterActive && m.filterPattern != "" {
+		return statusBarStyle.Render("Filter: " + m.filterPattern)
+	}
 	return statusBarStyle.Render("")
 }


### PR DESCRIPTION
## Summary
- Press `/` in Normal mode to activate live filter input in footer
- Case-insensitive substring matching on item display IDs in real-time
- Enter confirms filter (items stay filtered), Esc clears and restores all items
- Active filter pattern shown in status bar ("Filter: foo")
- Cursor resets to first item when filter changes
- Navigation works correctly on filtered lists
- Unit tests cover substring matching, case insensitivity, empty pattern, no matches, Data section passthrough

## Test plan
- [ ] Press `/` to open filter input in footer
- [ ] Type to see items filtered in real-time
- [ ] Verify case-insensitive matching
- [ ] Press Enter to confirm filter — items stay filtered, returns to Normal
- [ ] Press Esc to clear filter — all items restored
- [ ] Status bar shows "Filter: <pattern>" when filter is active
- [ ] Navigation (j/k/h/l) works correctly on filtered list
- [ ] All unit tests pass

Closes #22