### PR TITLE
feat(browse): add paginated collection loading with Load more

### DIFF
--- a/pkg/cmd/browse/command.go
+++ b/pkg/cmd/browse/command.go
@@ -3,6 +3,7 @@ package browse
 import (
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 
 	"cloud.google.com/go/firestore"
@@ -75,6 +76,7 @@ type pendingFetchCmd struct {
 	colIndex  int
 	sortField string
 	sortDir   firestore.Direction
+	opts      []fetchOption
 }
 
 func initCommandRegistry() *CommandRegistry {
@@ -106,6 +108,13 @@ func initCommandRegistry() *CommandRegistry {
 		Description: "Sort collection by field",
 		Usage:       ":sort <field> [asc|desc]",
 		Handler:     cmdSort,
+	})
+
+	r.Register(Command{
+		Name:        "set",
+		Description: "Set a configuration value",
+		Usage:       ":set limit <n>",
+		Handler:     cmdSet,
 	})
 
 	return r
@@ -140,7 +149,7 @@ func cmdGoto(m *Model, args []string) (string, error) {
 	m.loading = true
 
 	sortField, sortDir := m.getSortParams(path)
-	m.pendingFetch = &pendingFetchCmd{path: path, isDoc: isDoc, colIndex: 0, sortField: sortField, sortDir: sortDir}
+	m.pendingFetch = &pendingFetchCmd{path: path, isDoc: isDoc, colIndex: 0, sortField: sortField, sortDir: sortDir, opts: []fetchOption{withLimit(m.pageLimit)}}
 
 	return fmt.Sprintf("Navigating to /%s", path), nil
 }
@@ -154,7 +163,7 @@ func cmdRefresh(m *Model, args []string) (string, error) {
 	m.loading = true
 
 	sortField, sortDir := m.getSortParams(col.path)
-	m.pendingFetch = &pendingFetchCmd{path: col.path, isDoc: col.isDoc, colIndex: m.activeColumn, sortField: sortField, sortDir: sortDir}
+	m.pendingFetch = &pendingFetchCmd{path: col.path, isDoc: col.isDoc, colIndex: m.activeColumn, sortField: sortField, sortDir: sortDir, opts: []fetchOption{withLimit(m.pageLimit)}}
 
 	return "Refreshing...", nil
 }
@@ -192,11 +201,29 @@ func cmdSort(m *Model, args []string) (string, error) {
 	}
 
 	m.loading = true
-	m.pendingFetch = &pendingFetchCmd{path: col.path, isDoc: col.isDoc, colIndex: m.activeColumn, sortField: field, sortDir: dir}
+	m.pendingFetch = &pendingFetchCmd{path: col.path, isDoc: col.isDoc, colIndex: m.activeColumn, sortField: field, sortDir: dir, opts: []fetchOption{withLimit(m.pageLimit)}}
 
 	dirStr := "Ascending"
 	if dir == firestore.Desc {
 		dirStr = "Descending"
 	}
 	return fmt.Sprintf("Sorted by %s (%s)", field, dirStr), nil
+}
+
+func cmdSet(m *Model, args []string) (string, error) {
+	if len(args) < 2 {
+		return "", fmt.Errorf("usage: :set limit <n>")
+	}
+
+	switch args[0] {
+	case "limit":
+		n, err := strconv.Atoi(args[1])
+		if err != nil || n < 1 {
+			return "", fmt.Errorf("limit must be a positive integer")
+		}
+		m.pageLimit = n
+		return fmt.Sprintf("Page limit set to %d", n), nil
+	default:
+		return "", fmt.Errorf("unknown setting: %s", args[0])
+	}
 }

--- a/pkg/cmd/browse/firestore.go
+++ b/pkg/cmd/browse/firestore.go
@@ -92,6 +92,26 @@ func createNode(key string, value interface{}, depth int) ListItem {
 	return item
 }
 
+type fetchOpts struct {
+	limit       int
+	offset      int
+	appendItems bool
+}
+
+type fetchOption func(*fetchOpts)
+
+func withLimit(n int) fetchOption {
+	return func(o *fetchOpts) { o.limit = n }
+}
+
+func withOffset(n int) fetchOption {
+	return func(o *fetchOpts) { o.offset = n }
+}
+
+func withAppend() fetchOption {
+	return func(o *fetchOpts) { o.appendItems = true }
+}
+
 func deleteDocument(client *firestore.Client, path string, fromDocView bool) tea.Cmd {
 	return func() tea.Msg {
 		ctx := context.Background()
@@ -105,15 +125,20 @@ func deleteDocument(client *firestore.Client, path string, fromDocView bool) tea
 }
 
 // fetchColumnData fetches data for a specific column based on path and type
-func fetchColumnData(client *firestore.Client, path string, isDoc bool, columnIndex int, sortField string, sortDirection firestore.Direction) tea.Cmd {
+func fetchColumnData(client *firestore.Client, path string, isDoc bool, columnIndex int, sortField string, sortDirection firestore.Direction, opts ...fetchOption) tea.Cmd {
+	var fo fetchOpts
+	for _, o := range opts {
+		o(&fo)
+	}
 	return func() tea.Msg {
-		logDebug("fetchColumnData started: path='%s', isDoc=%v, columnIndex=%d, sortField='%s'", path, isDoc, columnIndex, sortField)
+		logDebug("fetchColumnData started: path='%s', isDoc=%v, columnIndex=%d, sortField='%s', limit=%d, offset=%d", path, isDoc, columnIndex, sortField, fo.limit, fo.offset)
 		ctx := context.Background()
 		sections := []Section{}
 		docContent := ""
 		var docData map[string]interface{}
 		docMetadata := map[string]string{}
 		availableFields := []string{}
+		hasMore := false
 
 		if path == "" {
 			// Root: fetch root collections
@@ -150,9 +175,18 @@ func fetchColumnData(client *firestore.Client, path string, isDoc bool, columnIn
 				query = query.OrderBy(sortField, sortDirection)
 			}
 
+			// Apply pagination limit
+			if fo.limit > 0 {
+				query = query.Limit(fo.limit + 1) // Fetch one extra to detect hasMore
+				if fo.offset > 0 {
+					query = query.Offset(fo.offset)
+				}
+			}
+
 			iter := query.Documents(ctx)
 			var items []ListItem
 			firstDoc := true
+			fetchCount := 0
 			for {
 				doc, err := iter.Next()
 				if err == iterator.Done {
@@ -162,6 +196,13 @@ func fetchColumnData(client *firestore.Client, path string, isDoc bool, columnIn
 					return errorMsg{err: err}
 				}
 
+				fetchCount++
+				// If we got more than limit, we have more pages
+				if fo.limit > 0 && fetchCount > fo.limit {
+					hasMore = true
+					break
+				}
+
 				// Extract field names from first document
 				if firstDoc {
 					firstDoc = false
@@ -169,7 +210,6 @@ func fetchColumnData(client *firestore.Client, path string, isDoc bool, columnIn
 					for key := range data {
 						availableFields = append(availableFields, key)
 					}
-					// Sort field names for consistent order
 					sort.Strings(availableFields)
 				}
 
@@ -177,7 +217,6 @@ func fetchColumnData(client *firestore.Client, path string, isDoc bool, columnIn
 				if !doc.CreateTime.IsZero() {
 					metadata["created"] = doc.CreateTime.Local().Format("2006-01-02 15:04:05")
 				}
-				// Build relative path: parent_path/doc_id
 				docPath := path + "/" + doc.Ref.ID
 				items = append(items, ListItem{
 					id:       doc.Ref.ID,
@@ -186,29 +225,41 @@ func fetchColumnData(client *firestore.Client, path string, isDoc bool, columnIn
 					metadata: metadata,
 				})
 			}
-			seen := make(map[string]bool, len(items))
-			for _, item := range items {
-				seen[item.id] = true
+
+			// Only fetch document refs for missing docs on first page
+			if fo.offset == 0 {
+				seen := make(map[string]bool, len(items))
+				for _, item := range items {
+					seen[item.id] = true
+				}
+
+				refsIter := colRef.DocumentRefs(ctx)
+				for {
+					ref, err := refsIter.Next()
+					if err == iterator.Done {
+						break
+					}
+					if err != nil {
+						return errorMsg{err: err}
+					}
+					if seen[ref.ID] {
+						continue
+					}
+					docPath := path + "/" + ref.ID
+					items = append(items, ListItem{
+						id:        ref.ID,
+						path:      docPath,
+						isDoc:     true,
+						isMissing: true,
+					})
+				}
 			}
 
-			refsIter := colRef.DocumentRefs(ctx)
-			for {
-				ref, err := refsIter.Next()
-				if err == iterator.Done {
-					break
-				}
-				if err != nil {
-					return errorMsg{err: err}
-				}
-				if seen[ref.ID] {
-					continue
-				}
-				docPath := path + "/" + ref.ID
+			// Add "Load more..." sentinel if there are more pages
+			if hasMore {
 				items = append(items, ListItem{
-					id:        ref.ID,
-					path:      docPath,
-					isDoc:     true,
-					isMissing: true,
+					id:   "Load more...",
+					path: "__load_more__",
 				})
 			}
 
@@ -312,6 +363,18 @@ func fetchColumnData(client *firestore.Client, path string, isDoc bool, columnIn
 			}
 		}
 
+		// Count documents in sections
+		totalDocs := 0
+		for _, s := range sections {
+			if s.title == "Documents" {
+				for _, item := range s.items {
+					if item.path != "__load_more__" {
+						totalDocs++
+					}
+				}
+			}
+		}
+
 		result := fetchedColumnMsg{
 			columnIndex:     columnIndex,
 			sections:        sections,
@@ -319,6 +382,9 @@ func fetchColumnData(client *firestore.Client, path string, isDoc bool, columnIn
 			docData:         docData,
 			docMetadata:     docMetadata,
 			availableFields: availableFields,
+			hasMore:         hasMore,
+			docCount:        totalDocs,
+			appendItems:     fo.appendItems,
 		}
 		logDebug("fetchColumnData completed: columnIndex=%d, sections=%d, docContentLen=%d, docData keys=%d",
 			columnIndex, len(sections), len(docContent), len(docData))

--- a/pkg/cmd/browse/model.go
+++ b/pkg/cmd/browse/model.go
@@ -76,6 +76,9 @@ type Model struct {
 	statusMsg     string    // Status message to display
 	statusMsgTime time.Time // When status message was set
 
+	// Pagination
+	pageLimit int
+
 	// Delete confirmation
 	deletePath        string // Path of document pending deletion
 	deleteFromDocView bool   // Whether delete was initiated from a document column
@@ -104,6 +107,8 @@ type Column struct {
 	viewport        viewport.Model         // Scrollable viewport for document content
 	cursor          int                    // Selected index across all items
 	scrollOffset    int                    // Scroll position for lists
+	hasMore         bool                   // true if more pages available
+	docCount        int                    // total document count loaded so far
 }
 
 // Section represents a section within a column (Documents or Subcollections)
@@ -139,6 +144,9 @@ type fetchedColumnMsg struct {
 	docData         map[string]interface{}
 	docMetadata     map[string]string
 	availableFields []string
+	hasMore         bool
+	docCount        int
+	appendItems     bool // true when loading more pages (append to existing)
 }
 
 type errorMsg struct {
@@ -193,7 +201,7 @@ func (m Model) Init() tea.Cmd {
 		sortField, sortDir := m.getSortParams(m.columns[0].path)
 		return tea.Batch(
 			textinput.Blink,
-			fetchColumnData(m.client, m.columns[0].path, m.columns[0].isDoc, 0, sortField, sortDir),
+			fetchColumnData(m.client, m.columns[0].path, m.columns[0].isDoc, 0, sortField, sortDir, withLimit(m.pageLimit)),
 		)
 	}
 	return textinput.Blink

--- a/pkg/cmd/browse/root.go
+++ b/pkg/cmd/browse/root.go
@@ -113,6 +113,7 @@ Examples:
 				commandRegistry: initCommandRegistry(),
 				commandInput:    ci,
 				filterInput:     fi,
+				pageLimit:       50,
 			}
 
 			// Run TUI

--- a/pkg/cmd/browse/update.go
+++ b/pkg/cmd/browse/update.go
@@ -90,18 +90,38 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case fetchedColumnMsg:
-		logDebug("fetchedColumnMsg received: columnIndex=%d, sections=%d, docContentLen=%d",
-			msg.columnIndex, len(msg.sections), len(msg.docContent))
-		// Update the specified column with fetched data
+		logDebug("fetchedColumnMsg received: columnIndex=%d, sections=%d, docContentLen=%d, append=%v",
+			msg.columnIndex, len(msg.sections), len(msg.docContent), msg.appendItems)
 		if msg.columnIndex < len(m.columns) {
-			m.columns[msg.columnIndex].sections = msg.sections
-			m.columns[msg.columnIndex].docContent = msg.docContent
-			m.columns[msg.columnIndex].docData = msg.docData
-			m.columns[msg.columnIndex].docMetadata = msg.docMetadata
-			if len(msg.availableFields) > 0 {
-				m.columns[msg.columnIndex].availableFields = msg.availableFields
+			if msg.appendItems {
+				// Append new items to existing sections
+				col := &m.columns[msg.columnIndex]
+				for i, newSection := range msg.sections {
+					if i < len(col.sections) && col.sections[i].title == newSection.title {
+						// Remove old "Load more..." sentinel
+						existingItems := col.sections[i].items
+						if len(existingItems) > 0 && existingItems[len(existingItems)-1].path == "__load_more__" {
+							existingItems = existingItems[:len(existingItems)-1]
+						}
+						// Append new items
+						col.sections[i].items = append(existingItems, newSection.items...)
+						col.sections[i].hidden = len(col.sections[i].items) == 0
+					}
+				}
+				col.hasMore = msg.hasMore
+				col.docCount += msg.docCount
+			} else {
+				m.columns[msg.columnIndex].sections = msg.sections
+				m.columns[msg.columnIndex].docContent = msg.docContent
+				m.columns[msg.columnIndex].docData = msg.docData
+				m.columns[msg.columnIndex].docMetadata = msg.docMetadata
+				if len(msg.availableFields) > 0 {
+					m.columns[msg.columnIndex].availableFields = msg.availableFields
+				}
+				m.columns[msg.columnIndex].scrollOffset = 0
+				m.columns[msg.columnIndex].hasMore = msg.hasMore
+				m.columns[msg.columnIndex].docCount = msg.docCount
 			}
-			m.columns[msg.columnIndex].scrollOffset = 0 // Reset scroll to top when new data arrives
 
 			// Initialize viewport if this is a document column
 			// Only create viewport if we have valid dimensions
@@ -200,7 +220,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.loading = true
 
 			return m, tea.Batch(
-				fetchColumnData(m.client, col.path, col.isDoc, m.activeColumn, sortField, sortDir),
+				fetchColumnData(m.client, col.path, col.isDoc, m.activeColumn, sortField, sortDir, withLimit(m.pageLimit)),
 				clearStatusAfterDelay(),
 			)
 		}
@@ -316,6 +336,17 @@ func (m Model) handleKeyPress(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		item := m.getSelectedItem()
 		logDebug("Forward navigation - selected item: %v", item)
 		if item != nil {
+			// Handle "Load more..." sentinel
+			if item.path == "__load_more__" {
+				if m.activeColumn < len(m.columns) {
+					col := m.columns[m.activeColumn]
+					m.loading = true
+					sortField, sortDir := m.getSortParams(col.path)
+					return m, fetchColumnData(m.client, col.path, col.isDoc, m.activeColumn, sortField, sortDir,
+						withLimit(m.pageLimit), withOffset(col.docCount), withAppend())
+				}
+				return m, nil
+			}
 			if item.isData {
 				// Handle tree expansion/toggle
 				if msg.String() == "enter" {
@@ -331,7 +362,7 @@ func (m Model) handleKeyPress(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.loading = true
 			logDebug("Fetching data for column %d", len(m.columns)-1)
 			sortField, sortDir := m.getSortParams(item.path)
-			return m, fetchColumnData(m.client, item.path, item.isDoc, len(m.columns)-1, sortField, sortDir)
+			return m, fetchColumnData(m.client, item.path, item.isDoc, len(m.columns)-1, sortField, sortDir, withLimit(m.pageLimit))
 		}
 		return m, nil
 
@@ -383,7 +414,7 @@ func (m Model) handleKeyPress(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.loading = true
 
 		return m, tea.Batch(
-			fetchColumnData(m.client, col.path, col.isDoc, m.activeColumn, "", 0),
+			fetchColumnData(m.client, col.path, col.isDoc, m.activeColumn, "", 0, withLimit(m.pageLimit)),
 			clearStatusAfterDelay(),
 		)
 
@@ -408,7 +439,7 @@ func (m Model) handleKeyPress(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			col := m.columns[m.activeColumn]
 			m.loading = true
 			sortField, sortDir := m.getSortParams(col.path)
-			return m, fetchColumnData(m.client, col.path, col.isDoc, m.activeColumn, sortField, sortDir)
+			return m, fetchColumnData(m.client, col.path, col.isDoc, m.activeColumn, sortField, sortDir, withLimit(m.pageLimit))
 		}
 		return m, nil
 
@@ -467,7 +498,7 @@ func (m Model) handleOverlay(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.textInput.Reset()
 			m.loading = true
 			sortField, sortDir := m.getSortParams(path)
-			return m, fetchColumnData(m.client, path, isDoc, 0, sortField, sortDir)
+			return m, fetchColumnData(m.client, path, isDoc, 0, sortField, sortDir, withLimit(m.pageLimit))
 		case "esc":
 			m.overlay = OverlayNone
 			m.textInput.Blur()
@@ -600,7 +631,7 @@ func (m Model) applySortAndClose() (tea.Model, tea.Cmd) {
 	m.statusMsgTime = time.Now()
 
 	return m, tea.Batch(
-		fetchColumnData(m.client, col.path, col.isDoc, m.activeColumn, field, m.sortDialog.direction),
+		fetchColumnData(m.client, col.path, col.isDoc, m.activeColumn, field, m.sortDialog.direction, withLimit(m.pageLimit)),
 		clearStatusAfterDelay(),
 	)
 }
@@ -650,7 +681,7 @@ func (m Model) handleCommandMode(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			pf := m.pendingFetch
 			m.pendingFetch = nil
 			return m, tea.Batch(
-				fetchColumnData(m.client, pf.path, pf.isDoc, pf.colIndex, pf.sortField, pf.sortDir),
+				fetchColumnData(m.client, pf.path, pf.isDoc, pf.colIndex, pf.sortField, pf.sortDir, pf.opts...),
 				clearStatusAfterDelay(),
 			)
 		}

--- a/pkg/cmd/browse/view.go
+++ b/pkg/cmd/browse/view.go
@@ -657,8 +657,24 @@ func (m Model) getFooterHints() string {
 
 // renderStatusBar renders the status bar area between columns and footer
 func (m Model) renderStatusBar() string {
+	var parts []string
+
+	// Show pagination info for active collection column
+	if m.activeColumn < len(m.columns) {
+		col := m.columns[m.activeColumn]
+		if !col.isDoc && col.docCount > 0 {
+			info := fmt.Sprintf("%d docs | limit: %d", col.docCount, m.pageLimit)
+			parts = append(parts, info)
+		}
+	}
+
+	// Show active filter
 	if m.filterActive && m.filterPattern != "" {
-		return statusBarStyle.Render("Filter: " + m.filterPattern)
+		parts = append(parts, "Filter: "+m.filterPattern)
+	}
+
+	if len(parts) > 0 {
+		return statusBarStyle.Render(strings.Join(parts, "  "))
 	}
 	return statusBarStyle.Render("")
 }


### PR DESCRIPTION
## Summary
- Add cursor-based pagination to collection fetching (default 50 docs per page)
- "Load more..." sentinel item appears when more pages are available
- `:set limit <n>` command to change page size at runtime
- Status bar shows document count and page limit

## Test plan
- [ ] Collections with >50 docs show "Load more..." at bottom
- [ ] Pressing Enter on "Load more..." loads next page
- [ ] `:set limit 10` changes page size
- [ ] All existing tests pass

Closes #21