### PR TITLE
feat(browse): add visual selection and bulk delete

### DIFF
--- a/pkg/cmd/browse/firestore.go
+++ b/pkg/cmd/browse/firestore.go
@@ -112,6 +112,26 @@ func withAppend() fetchOption {
 	return func(o *fetchOpts) { o.appendItems = true }
 }
 
+type bulkDeletedMsg struct {
+	count    int
+	colIndex int
+}
+
+func bulkDeleteDocuments(client *firestore.Client, paths []string, colIndex int) tea.Cmd {
+	return func() tea.Msg {
+		ctx := context.Background()
+		deleted := 0
+		for _, path := range paths {
+			docRef := client.Doc(strings.TrimPrefix(path, "/"))
+			if _, err := docRef.Delete(ctx); err != nil {
+				return errorMsg{err: fmt.Errorf("failed to delete %s: %w", path, err)}
+			}
+			deleted++
+		}
+		return bulkDeletedMsg{count: deleted, colIndex: colIndex}
+	}
+}
+
 func deleteDocument(client *firestore.Client, path string, fromDocView bool) tea.Cmd {
 	return func() tea.Msg {
 		ctx := context.Background()

--- a/pkg/cmd/browse/model.go
+++ b/pkg/cmd/browse/model.go
@@ -79,9 +79,13 @@ type Model struct {
 	// Pagination
 	pageLimit int
 
+	// Visual mode selection
+	selection *Selection
+
 	// Delete confirmation
 	deletePath        string // Path of document pending deletion
 	deleteFromDocView bool   // Whether delete was initiated from a document column
+	bulkDeletePaths   []string // Paths for bulk delete in visual mode
 
 	// Filter
 	filterInput   textinput.Model

--- a/pkg/cmd/browse/root.go
+++ b/pkg/cmd/browse/root.go
@@ -114,6 +114,7 @@ Examples:
 				commandInput:    ci,
 				filterInput:     fi,
 				pageLimit:       50,
+				selection:       NewSelection(),
 			}
 
 			// Run TUI

--- a/pkg/cmd/browse/selection.go
+++ b/pkg/cmd/browse/selection.go
@@ -1,0 +1,69 @@
+package browse
+
+// Selection tracks a set of selected indices with optional range-select anchor.
+type Selection struct {
+	indices map[int]bool
+	anchor  int
+	hasAnchor bool
+}
+
+func NewSelection() *Selection {
+	return &Selection{
+		indices: make(map[int]bool),
+	}
+}
+
+func (s *Selection) Toggle(index int) {
+	if s.indices[index] {
+		delete(s.indices, index)
+	} else {
+		s.indices[index] = true
+	}
+	s.hasAnchor = false
+}
+
+func (s *Selection) SetAnchor(index int) {
+	s.hasAnchor = true
+	s.anchor = index
+	s.indices[index] = true
+}
+
+func (s *Selection) ExtendTo(index int) {
+	if !s.hasAnchor {
+		return
+	}
+	// Clear previous range, keep only anchor
+	s.indices = map[int]bool{s.anchor: true}
+	start, end := s.anchor, index
+	if start > end {
+		start, end = end, start
+	}
+	for i := start; i <= end; i++ {
+		s.indices[i] = true
+	}
+}
+
+func (s *Selection) IsSelected(index int) bool {
+	return s.indices[index]
+}
+
+func (s *Selection) Count() int {
+	return len(s.indices)
+}
+
+func (s *Selection) Indices() []int {
+	result := make([]int, 0, len(s.indices))
+	for i := range s.indices {
+		result = append(result, i)
+	}
+	return result
+}
+
+func (s *Selection) Clear() {
+	s.indices = make(map[int]bool)
+	s.hasAnchor = false
+}
+
+func (s *Selection) HasAnchor() bool {
+	return s.hasAnchor
+}

--- a/pkg/cmd/browse/selection_test.go
+++ b/pkg/cmd/browse/selection_test.go
@@ -1,0 +1,117 @@
+package browse
+
+import (
+	"sort"
+	"testing"
+)
+
+func TestSelectionToggle(t *testing.T) {
+	s := NewSelection()
+
+	s.Toggle(3)
+	if !s.IsSelected(3) {
+		t.Error("expected index 3 to be selected")
+	}
+	if s.Count() != 1 {
+		t.Errorf("expected count 1, got %d", s.Count())
+	}
+
+	s.Toggle(3)
+	if s.IsSelected(3) {
+		t.Error("expected index 3 to be deselected")
+	}
+	if s.Count() != 0 {
+		t.Errorf("expected count 0, got %d", s.Count())
+	}
+}
+
+func TestSelectionRangeSelect(t *testing.T) {
+	s := NewSelection()
+
+	s.SetAnchor(2)
+	s.ExtendTo(5)
+
+	expected := []int{2, 3, 4, 5}
+	if s.Count() != len(expected) {
+		t.Errorf("expected count %d, got %d", len(expected), s.Count())
+	}
+	for _, i := range expected {
+		if !s.IsSelected(i) {
+			t.Errorf("expected index %d to be selected", i)
+		}
+	}
+}
+
+func TestSelectionRangeSelectReverse(t *testing.T) {
+	s := NewSelection()
+
+	s.SetAnchor(5)
+	s.ExtendTo(2)
+
+	expected := []int{2, 3, 4, 5}
+	if s.Count() != len(expected) {
+		t.Errorf("expected count %d, got %d", len(expected), s.Count())
+	}
+	for _, i := range expected {
+		if !s.IsSelected(i) {
+			t.Errorf("expected index %d to be selected", i)
+		}
+	}
+}
+
+func TestSelectionRangeExtendUpdates(t *testing.T) {
+	s := NewSelection()
+
+	s.SetAnchor(3)
+	s.ExtendTo(6)
+	if s.Count() != 4 {
+		t.Errorf("expected count 4, got %d", s.Count())
+	}
+
+	// Shrink range
+	s.ExtendTo(4)
+	if s.Count() != 2 {
+		t.Errorf("expected count 2, got %d", s.Count())
+	}
+	if !s.IsSelected(3) || !s.IsSelected(4) {
+		t.Error("expected indices 3 and 4 to be selected")
+	}
+	if s.IsSelected(5) || s.IsSelected(6) {
+		t.Error("expected indices 5 and 6 to be deselected")
+	}
+}
+
+func TestSelectionClear(t *testing.T) {
+	s := NewSelection()
+	s.Toggle(1)
+	s.Toggle(2)
+	s.Toggle(3)
+
+	s.Clear()
+	if s.Count() != 0 {
+		t.Errorf("expected count 0 after clear, got %d", s.Count())
+	}
+	if s.HasAnchor() {
+		t.Error("expected no anchor after clear")
+	}
+}
+
+func TestSelectionIndices(t *testing.T) {
+	s := NewSelection()
+	s.Toggle(5)
+	s.Toggle(1)
+	s.Toggle(3)
+
+	indices := s.Indices()
+	sort.Ints(indices)
+
+	expected := []int{1, 3, 5}
+	if len(indices) != len(expected) {
+		t.Fatalf("expected %d indices, got %d", len(expected), len(indices))
+	}
+	for i := range indices {
+		if indices[i] != expected[i] {
+			t.Errorf("indices[%d] = %d, want %d", i, indices[i], expected[i])
+		}
+	}
+}

--- a/pkg/cmd/browse/styles.go
+++ b/pkg/cmd/browse/styles.go
@@ -154,4 +154,10 @@ var (
 	statusBarStyle = lipgloss.NewStyle().
 			Foreground(colorGray).
 			Padding(0, 1)
+
+	// Visual mode selected item style
+	visualSelectedStyle = lipgloss.NewStyle().
+				Bold(true).
+				Foreground(lipgloss.Color("0")).
+				Background(colorYellow)
 )

--- a/pkg/cmd/browse/update.go
+++ b/pkg/cmd/browse/update.go
@@ -51,11 +51,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m.handleKeyPress(msg)
 
 		case ModeVisual:
-			if msg.String() == "esc" {
-				m.mode = ModeNormal
-				return m, nil
-			}
-			return m, nil
+			return m.handleVisualMode(msg)
 
 		case ModeCommand:
 			return m.handleCommandMode(msg)
@@ -243,6 +239,22 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		}
 		return m, handleEditorFinished(msg.session)
+
+	case bulkDeletedMsg:
+		m.loading = false
+		m.statusMsg = fmt.Sprintf("%d documents deleted", msg.count)
+		m.statusMsgTime = time.Now()
+
+		if msg.colIndex < len(m.columns) {
+			col := m.columns[msg.colIndex]
+			sortField, sortDir := m.getSortParams(col.path)
+			m.loading = true
+			return m, tea.Batch(
+				fetchColumnData(m.client, col.path, col.isDoc, msg.colIndex, sortField, sortDir, withLimit(m.pageLimit)),
+				clearStatusAfterDelay(),
+			)
+		}
+		return m, clearStatusAfterDelay()
 
 	}
 
@@ -443,6 +455,25 @@ func (m Model) handleKeyPress(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 
+	case "v":
+		// Toggle selection and enter visual mode
+		if m.activeColumn < len(m.columns) && !m.columns[m.activeColumn].isDoc {
+			col := m.columns[m.activeColumn]
+			cursor := col.cursor
+			m.selection.Toggle(cursor)
+			m.mode = ModeVisual
+		}
+		return m, nil
+
+	case "V":
+		// Range-select mode
+		if m.activeColumn < len(m.columns) && !m.columns[m.activeColumn].isDoc {
+			col := m.columns[m.activeColumn]
+			m.selection.SetAnchor(col.cursor)
+			m.mode = ModeVisual
+		}
+		return m, nil
+
 	case "d":
 		if m.activeColumn >= len(m.columns) {
 			return m, nil
@@ -542,16 +573,29 @@ func (m Model) handleOverlay(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case OverlayDeleteConfirm:
 		switch msg.String() {
 		case "y", "enter":
+			m.overlay = OverlayNone
+
+			// Bulk delete
+			if len(m.bulkDeletePaths) > 0 {
+				paths := m.bulkDeletePaths
+				m.bulkDeletePaths = nil
+				m.selection.Clear()
+				m.mode = ModeNormal
+				m.loading = true
+				return m, bulkDeleteDocuments(m.client, paths, m.activeColumn)
+			}
+
+			// Single delete
 			path := m.deletePath
 			fromDocView := m.deleteFromDocView
 			m.deletePath = ""
 			m.deleteFromDocView = false
-			m.overlay = OverlayNone
 			m.loading = true
 			return m, deleteDocument(m.client, path, fromDocView)
 		case "n", "esc", "q":
 			m.deletePath = ""
 			m.deleteFromDocView = false
+			m.bulkDeletePaths = nil
 			m.overlay = OverlayNone
 			return m, nil
 		}
@@ -712,6 +756,93 @@ func (m Model) handleCommandMode(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	m.commandInput, cmd = m.commandInput.Update(msg)
 	m.commandResult = ""
 	return m, cmd
+}
+
+// handleVisualMode processes keyboard input in Visual mode
+func (m Model) handleVisualMode(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "esc":
+		m.mode = ModeNormal
+		m.selection.Clear()
+		return m, nil
+
+	case "v":
+		// Toggle selection on current item
+		if m.activeColumn < len(m.columns) {
+			m.selection.Toggle(m.columns[m.activeColumn].cursor)
+			if m.selection.Count() == 0 {
+				m.mode = ModeNormal
+			}
+		}
+		return m, nil
+
+	case "j", "down":
+		m.moveCursor(1)
+		if m.selection.HasAnchor() && m.activeColumn < len(m.columns) {
+			m.selection.ExtendTo(m.columns[m.activeColumn].cursor)
+		}
+		return m, nil
+
+	case "k", "up":
+		m.moveCursor(-1)
+		if m.selection.HasAnchor() && m.activeColumn < len(m.columns) {
+			m.selection.ExtendTo(m.columns[m.activeColumn].cursor)
+		}
+		return m, nil
+
+	case "g":
+		m.jumpToTop()
+		if m.selection.HasAnchor() && m.activeColumn < len(m.columns) {
+			m.selection.ExtendTo(m.columns[m.activeColumn].cursor)
+		}
+		return m, nil
+
+	case "G":
+		m.jumpToBottom()
+		if m.selection.HasAnchor() && m.activeColumn < len(m.columns) {
+			m.selection.ExtendTo(m.columns[m.activeColumn].cursor)
+		}
+		return m, nil
+
+	case "d":
+		// Bulk delete selected items
+		if m.selection.Count() == 0 {
+			return m, nil
+		}
+
+		if m.activeColumn >= len(m.columns) {
+			return m, nil
+		}
+
+		// Collect paths of selected items
+		col := m.columns[m.activeColumn]
+		sections := m.getEffectiveSections(col)
+		var paths []string
+		itemIndex := 0
+		for _, section := range sections {
+			if section.hidden {
+				continue
+			}
+			for _, item := range section.items {
+				if m.selection.IsSelected(itemIndex) && item.isDoc && item.path != "__load_more__" {
+					paths = append(paths, item.path)
+				}
+				itemIndex++
+			}
+		}
+
+		if len(paths) == 0 {
+			m.statusMsg = "No documents selected"
+			m.statusMsgTime = time.Now()
+			return m, clearStatusAfterDelay()
+		}
+
+		m.bulkDeletePaths = paths
+		m.overlay = OverlayDeleteConfirm
+		return m, nil
+	}
+
+	return m, nil
 }
 
 func longestCommonPrefix(strs []string) string {

--- a/pkg/cmd/browse/view.go
+++ b/pkg/cmd/browse/view.go
@@ -45,7 +45,8 @@ func (m Model) View() string {
 	modeIndicator := modeNormalStyle.Render("[" + m.mode.String() + "]")
 	switch m.mode {
 	case ModeVisual:
-		modeIndicator = modeVisualStyle.Render("[VISUAL]")
+		label := fmt.Sprintf("[VISUAL %d]", m.selection.Count())
+		modeIndicator = modeVisualStyle.Render(label)
 	case ModeCommand:
 		modeIndicator = modeCommandStyle.Render("[COMMAND]")
 	}
@@ -137,17 +138,24 @@ func (m Model) View() string {
 	}
 
 	if m.overlay == OverlayDeleteConfirm {
-		parts := strings.Split(m.deletePath, "/")
-		docID := m.deletePath
-		if len(parts) > 0 {
-			docID = parts[len(parts)-1]
+		var dialogTitle, dialogDetail string
+		if len(m.bulkDeletePaths) > 0 {
+			dialogTitle = fmt.Sprintf("Delete %d documents?", len(m.bulkDeletePaths))
+			dialogDetail = ""
+		} else {
+			dialogTitle = "Delete document?"
+			parts := strings.Split(m.deletePath, "/")
+			dialogDetail = m.deletePath
+			if len(parts) > 0 {
+				dialogDetail = parts[len(parts)-1]
+			}
 		}
 
 		dialogContent := lipgloss.JoinVertical(
 			lipgloss.Center,
-			errorStyle.Render("Delete document?"),
+			errorStyle.Render(dialogTitle),
 			"",
-			docID,
+			dialogDetail,
 			"",
 			footerStyle.Render("y/Enter: confirm  n/Esc: cancel"),
 		)
@@ -450,9 +458,13 @@ func (m Model) renderColumn(col Column, width int, isActive bool) string {
 					prefix = "> "
 				}
 
-				// Calculate space available for ID
-				// prefix(2) + space(1) = 3 chars roughly (ignoring ansi)
-				extraChars := 3
+				// Visual selection marker
+				selMark := " "
+				if m.mode == ModeVisual && m.selection.IsSelected(itemIndex) {
+					selMark = "●"
+				}
+
+				extraChars := 4
 				availWidth := max(innerWidth-extraChars, 5)
 
 				displayID := item.id
@@ -460,17 +472,20 @@ func (m Model) renderColumn(col Column, width int, isActive bool) string {
 					displayID = displayID[:availWidth-3] + "..."
 				}
 
-				line := fmt.Sprintf("%s%s", prefix, displayID)
+				line := fmt.Sprintf("%s%s%s", prefix, selMark, displayID)
 				if item.isMissing {
-					line = fmt.Sprintf("%s%s", prefix, missingDocStyle.Render(displayID+" (no data)"))
+					line = fmt.Sprintf("%s%s%s", prefix, selMark, missingDocStyle.Render(displayID+" (no data)"))
 				}
-				if itemIndex == col.cursor {
+
+				if m.mode == ModeVisual && m.selection.IsSelected(itemIndex) {
+					line = visualSelectedStyle.Render(line)
+				} else if itemIndex == col.cursor {
 					line = selectedItemStyle.Render(
-						fmt.Sprintf("%s%s", prefix, displayID),
+						fmt.Sprintf("%s%s%s", prefix, selMark, displayID),
 					)
 					if item.isMissing {
 						line = selectedItemStyle.Render(
-							fmt.Sprintf("%s%s (no data)", prefix, displayID),
+							fmt.Sprintf("%s%s%s (no data)", prefix, selMark, displayID),
 						)
 					}
 				}
@@ -647,7 +662,7 @@ func (m Model) getFooterHints() string {
 
 	switch m.mode {
 	case ModeVisual:
-		return "Esc: Normal mode"
+		return "v: Toggle select  j/k: Move  d: Delete selected  Esc: Cancel"
 	case ModeCommand:
 		return "Esc: Normal mode"
 	default:


### PR DESCRIPTION
## Summary
- `v` toggles selection on current item and enters Visual mode
- `V` starts range-select with anchor; j/k extends selection
- Selected items highlighted with yellow background and bullet marker
- Header shows `[VISUAL N]` with selection count
- `d` in Visual mode prompts bulk delete confirmation
- Bulk delete removes all selected documents and refreshes collection
- Esc exits Visual mode and clears selections
- Unit tests cover toggle, range-select, reverse range, extend/shrink, clear, indices

## Test plan
- [ ] `v` toggles selection and enters Visual mode
- [ ] `V` starts range select, j/k extends
- [ ] `d` shows "Delete N documents?" confirmation
- [ ] Confirming deletes all selected documents
- [ ] Esc clears selections
- [ ] All 15 unit tests pass

Closes #23