### PR TITLE
feat(browse): add :export command for JSON and NDJSON

### DIFF
--- a/pkg/cmd/browse/command.go
+++ b/pkg/cmd/browse/command.go
@@ -117,6 +117,13 @@ func initCommandRegistry() *CommandRegistry {
 		Handler:     cmdSet,
 	})
 
+	r.Register(Command{
+		Name:        "export",
+		Description: "Export documents as JSON or NDJSON",
+		Usage:       ":export json|ndjson [file]",
+		Handler:     cmdExport,
+	})
+
 	return r
 }
 

--- a/pkg/cmd/browse/export.go
+++ b/pkg/cmd/browse/export.go
@@ -1,0 +1,161 @@
+package browse
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/atotto/clipboard"
+)
+
+// ExportJSON serializes documents as a pretty-printed JSON array.
+func ExportJSON(docs []map[string]interface{}) (string, error) {
+	var buf bytes.Buffer
+	encoder := json.NewEncoder(&buf)
+	encoder.SetEscapeHTML(false)
+	encoder.SetIndent("", "  ")
+	if err := encoder.Encode(docs); err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(buf.String()), nil
+}
+
+// ExportNDJSON serializes documents as newline-delimited JSON (one object per line).
+func ExportNDJSON(docs []map[string]interface{}) (string, error) {
+	var lines []string
+	for _, doc := range docs {
+		var buf bytes.Buffer
+		encoder := json.NewEncoder(&buf)
+		encoder.SetEscapeHTML(false)
+		if err := encoder.Encode(doc); err != nil {
+			return "", err
+		}
+		lines = append(lines, strings.TrimSpace(buf.String()))
+	}
+	return strings.Join(lines, "\n"), nil
+}
+
+func cmdExport(m *Model, args []string) (string, error) {
+	if len(args) == 0 {
+		return "", fmt.Errorf("usage: :export json|ndjson [filename]")
+	}
+
+	format := strings.ToLower(args[0])
+	if format != "json" && format != "ndjson" {
+		return "", fmt.Errorf("unknown format %q, use json or ndjson", format)
+	}
+
+	filename := ""
+	if len(args) > 1 {
+		filename = args[1]
+	}
+
+	// Gather documents to export
+	docs, err := gatherExportDocs(m)
+	if err != nil {
+		return "", err
+	}
+
+	if len(docs) == 0 {
+		return "", fmt.Errorf("no documents to export")
+	}
+
+	// Serialize
+	var content string
+	switch format {
+	case "json":
+		content, err = ExportJSON(docs)
+	case "ndjson":
+		content, err = ExportNDJSON(docs)
+	}
+	if err != nil {
+		return "", fmt.Errorf("serialization error: %w", err)
+	}
+
+	// Write to file or clipboard
+	if filename != "" {
+		if err := os.WriteFile(filename, []byte(content+"\n"), 0644); err != nil {
+			return "", fmt.Errorf("failed to write file: %w", err)
+		}
+		return fmt.Sprintf("Exported %d documents to %s", len(docs), filename), nil
+	}
+
+	if err := clipboard.WriteAll(content); err != nil {
+		return "", fmt.Errorf("failed to copy to clipboard: %w", err)
+	}
+	return fmt.Sprintf("Exported %d documents to clipboard", len(docs)), nil
+}
+
+func gatherExportDocs(m *Model) ([]map[string]interface{}, error) {
+	if m.activeColumn >= len(m.columns) {
+		return nil, fmt.Errorf("no active column")
+	}
+
+	col := m.columns[m.activeColumn]
+
+	// Single document view
+	if col.isDoc && col.docData != nil {
+		return []map[string]interface{}{col.docData}, nil
+	}
+
+	// Collection view with visual selection
+	if m.selection.Count() > 0 {
+		return gatherSelectedDocs(m, col)
+	}
+
+	// All loaded documents in collection
+	return gatherAllDocs(m, col)
+}
+
+func gatherSelectedDocs(m *Model, col Column) ([]map[string]interface{}, error) {
+	sections := m.getEffectiveSections(col)
+	var paths []string
+	itemIndex := 0
+	for _, section := range sections {
+		if section.hidden {
+			continue
+		}
+		for _, item := range section.items {
+			if m.selection.IsSelected(itemIndex) && item.isDoc && item.path != "__load_more__" {
+				paths = append(paths, item.path)
+			}
+			itemIndex++
+		}
+	}
+
+	return fetchDocData(m, paths)
+}
+
+func gatherAllDocs(m *Model, col Column) ([]map[string]interface{}, error) {
+	sections := m.getEffectiveSections(col)
+	var paths []string
+	for _, section := range sections {
+		if section.hidden {
+			continue
+		}
+		for _, item := range section.items {
+			if item.isDoc && item.path != "__load_more__" {
+				paths = append(paths, item.path)
+			}
+		}
+	}
+
+	return fetchDocData(m, paths)
+}
+
+func fetchDocData(m *Model, paths []string) ([]map[string]interface{}, error) {
+	var docs []map[string]interface{}
+	for _, path := range paths {
+		docRef := m.client.Doc(strings.TrimPrefix(path, "/"))
+		snap, err := docRef.Get(m.ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch %s: %w", path, err)
+		}
+		if snap.Exists() {
+			docs = append(docs, snap.Data())
+		}
+	}
+	return docs, nil
+}

--- a/pkg/cmd/browse/export_test.go
+++ b/pkg/cmd/browse/export_test.go
@@ -1,0 +1,116 @@
+package browse
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestExportJSON(t *testing.T) {
+	docs := []map[string]interface{}{
+		{"name": "Alice", "age": float64(30)},
+		{"name": "Bob", "age": float64(25)},
+	}
+
+	result, err := ExportJSON(docs)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var parsed []map[string]interface{}
+	if err := json.Unmarshal([]byte(result), &parsed); err != nil {
+		t.Fatalf("result is not valid JSON: %v", err)
+	}
+
+	if len(parsed) != 2 {
+		t.Errorf("expected 2 docs, got %d", len(parsed))
+	}
+	if parsed[0]["name"] != "Alice" {
+		t.Errorf("expected Alice, got %v", parsed[0]["name"])
+	}
+}
+
+func TestExportJSONEmpty(t *testing.T) {
+	result, err := ExportJSON([]map[string]interface{}{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result != "[]" {
+		t.Errorf("expected [], got %q", result)
+	}
+}
+
+func TestExportJSONSingleDoc(t *testing.T) {
+	docs := []map[string]interface{}{
+		{"key": "value"},
+	}
+	result, err := ExportJSON(docs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(result, `"key"`) {
+		t.Errorf("expected key in result: %s", result)
+	}
+}
+
+func TestExportNDJSON(t *testing.T) {
+	docs := []map[string]interface{}{
+		{"name": "Alice"},
+		{"name": "Bob"},
+	}
+
+	result, err := ExportNDJSON(docs)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	lines := strings.Split(result, "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines, got %d", len(lines))
+	}
+
+	for _, line := range lines {
+		var obj map[string]interface{}
+		if err := json.Unmarshal([]byte(line), &obj); err != nil {
+			t.Errorf("line is not valid JSON: %q, err: %v", line, err)
+		}
+	}
+}
+
+func TestExportNDJSONEmpty(t *testing.T) {
+	result, err := ExportNDJSON([]map[string]interface{}{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result != "" {
+		t.Errorf("expected empty string, got %q", result)
+	}
+}
+
+func TestExportJSONNestedData(t *testing.T) {
+	docs := []map[string]interface{}{
+		{
+			"user": map[string]interface{}{
+				"name":  "Alice",
+				"roles": []interface{}{"admin", "user"},
+			},
+			"active": true,
+			"count":  float64(42),
+		},
+	}
+
+	result, err := ExportJSON(docs)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var parsed []map[string]interface{}
+	if err := json.Unmarshal([]byte(result), &parsed); err != nil {
+		t.Fatalf("result is not valid JSON: %v", err)
+	}
+
+	user := parsed[0]["user"].(map[string]interface{})
+	if user["name"] != "Alice" {
+		t.Errorf("expected nested name Alice, got %v", user["name"])
+	}
+}


### PR DESCRIPTION
## Summary
- `:export json [file]` exports as pretty-printed JSON array
- `:export ndjson [file]` exports as newline-delimited JSON
- Supports visual selection, single document view, or all loaded docs
- Writes to file if filename provided, otherwise copies to clipboard
- Unit tests cover JSON/NDJSON serialization, empty/single/nested data

## Test plan
- [ ] `:export json` copies JSON to clipboard
- [ ] `:export json output.json` writes to file
- [ ] `:export ndjson` copies NDJSON to clipboard
- [ ] Visual selection exports only selected docs
- [ ] All 21 unit tests pass

Closes #24