### PR TITLE
feat(browse): add vim-style marks for quick navigation

### DIFF
--- a/pkg/cmd/browse/command.go
+++ b/pkg/cmd/browse/command.go
@@ -124,6 +124,13 @@ func initCommandRegistry() *CommandRegistry {
 		Handler:     cmdExport,
 	})
 
+	r.Register(Command{
+		Name:        "marks",
+		Description: "List all current marks",
+		Usage:       ":marks",
+		Handler:     cmdMarks,
+	})
+
 	return r
 }
 
@@ -215,6 +222,26 @@ func cmdSort(m *Model, args []string) (string, error) {
 		dirStr = "Descending"
 	}
 	return fmt.Sprintf("Sorted by %s (%s)", field, dirStr), nil
+}
+
+func cmdMarks(m *Model, args []string) (string, error) {
+	if len(m.marks) == 0 {
+		return "No marks set", nil
+	}
+
+	// Sort marks by letter
+	var letters []rune
+	for k := range m.marks {
+		letters = append(letters, k)
+	}
+	sort.Slice(letters, func(i, j int) bool { return letters[i] < letters[j] })
+
+	var lines []string
+	for _, letter := range letters {
+		mark := m.marks[letter]
+		lines = append(lines, fmt.Sprintf("  '%c'  %s", letter, mark.path))
+	}
+	return "Marks:\n" + strings.Join(lines, "\n"), nil
 }
 
 func cmdSet(m *Model, args []string) (string, error) {

--- a/pkg/cmd/browse/model.go
+++ b/pkg/cmd/browse/model.go
@@ -82,6 +82,10 @@ type Model struct {
 	// Visual mode selection
 	selection *Selection
 
+	// Marks (vim-style bookmarks)
+	marks       map[rune]markEntry
+	pendingMark string // "m" or "'" when waiting for next key
+
 	// Delete confirmation
 	deletePath        string // Path of document pending deletion
 	deleteFromDocView bool   // Whether delete was initiated from a document column
@@ -138,6 +142,11 @@ type ListItem struct {
 	depth    int        // indentation level
 	expanded bool       // is expanded?
 	children []ListItem // children nodes (if object/array)
+}
+
+type markEntry struct {
+	path  string
+	isDoc bool
 }
 
 // Message types for async operations

--- a/pkg/cmd/browse/root.go
+++ b/pkg/cmd/browse/root.go
@@ -115,6 +115,7 @@ Examples:
 				filterInput:     fi,
 				pageLimit:       50,
 				selection:       NewSelection(),
+				marks:           make(map[rune]markEntry),
 			}
 
 			// Run TUI

--- a/pkg/cmd/browse/update.go
+++ b/pkg/cmd/browse/update.go
@@ -297,6 +297,40 @@ func (m Model) handleKeyPress(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.handleCopyAlternate()
 	}
 
+	// Handle pending mark operations
+	if m.pendingMark == "m" {
+		m.pendingMark = ""
+		if len(currentKey) == 1 && currentKey[0] >= 'a' && currentKey[0] <= 'z' {
+			letter := rune(currentKey[0])
+			if m.activeColumn < len(m.columns) {
+				col := m.columns[m.activeColumn]
+				m.marks[letter] = markEntry{path: col.path, isDoc: col.isDoc}
+				m.statusMsg = fmt.Sprintf("Mark '%c' set: %s", letter, col.path)
+				m.statusMsgTime = time.Now()
+				return m, clearStatusAfterDelay()
+			}
+		}
+		return m, nil
+	}
+	if m.pendingMark == "'" {
+		m.pendingMark = ""
+		if len(currentKey) == 1 && currentKey[0] >= 'a' && currentKey[0] <= 'z' {
+			letter := rune(currentKey[0])
+			mark, ok := m.marks[letter]
+			if !ok {
+				m.statusMsg = fmt.Sprintf("Mark '%c' not set", letter)
+				m.statusMsgTime = time.Now()
+				return m, clearStatusAfterDelay()
+			}
+			m.columns = []Column{{path: mark.path, isDoc: mark.isDoc, scrollOffset: 0}}
+			m.activeColumn = 0
+			m.loading = true
+			sortField, sortDir := m.getSortParams(mark.path)
+			return m, fetchColumnData(m.client, mark.path, mark.isDoc, 0, sortField, sortDir, withLimit(m.pageLimit))
+		}
+		return m, nil
+	}
+
 	// Any other key resets the double-tap tracking
 	if currentKey != "shift" && currentKey != "ctrl" && currentKey != "alt" {
 		m.lastKeyPress = ""
@@ -453,6 +487,14 @@ func (m Model) handleKeyPress(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			sortField, sortDir := m.getSortParams(col.path)
 			return m, fetchColumnData(m.client, col.path, col.isDoc, m.activeColumn, sortField, sortDir, withLimit(m.pageLimit))
 		}
+		return m, nil
+
+	case "m":
+		m.pendingMark = "m"
+		return m, nil
+
+	case "'":
+		m.pendingMark = "'"
 		return m, nil
 
 	case "v":


### PR DESCRIPTION
## Summary
- `m` + letter (a-z) sets a mark at current Firestore path
- `'` + letter jumps to marked path
- `:marks` lists all current marks with paths
- Setting a mark on used letter overwrites previous mark
- Jumping to unset mark shows error in status bar
- Marks are session-scoped (cleared on exit)

## Test plan
- [ ] `ma` sets mark 'a' at current path
- [ ] `'a` navigates to mark 'a'
- [ ] `:marks` shows all marks
- [ ] Jumping to unset mark shows error
- [ ] All 21 tests pass

Closes #25