### PR TITLE
feat(browse): add jumplist navigation with Ctrl+o / Ctrl+i

### DIFF
--- a/pkg/cmd/browse/command.go
+++ b/pkg/cmd/browse/command.go
@@ -154,6 +154,12 @@ func cmdGoto(m *Model, args []string) (string, error) {
 		isDoc = len(segments)%2 == 0
 	}
 
+	// Push current location to jumplist
+	if m.activeColumn < len(m.columns) {
+		cur := m.columns[m.activeColumn]
+		m.jumplist.Push(cur.path, cur.isDoc)
+	}
+
 	m.columns = []Column{{
 		path:         path,
 		isDoc:        isDoc,

--- a/pkg/cmd/browse/jumplist.go
+++ b/pkg/cmd/browse/jumplist.go
@@ -1,0 +1,48 @@
+package browse
+
+type JumpEntry struct {
+	Path  string
+	IsDoc bool
+}
+
+type Jumplist struct {
+	entries []JumpEntry
+	cursor  int
+}
+
+func NewJumplist() *Jumplist {
+	return &Jumplist{cursor: -1}
+}
+
+func (j *Jumplist) Push(path string, isDoc bool) {
+	// Truncate forward history
+	if j.cursor < len(j.entries)-1 {
+		j.entries = j.entries[:j.cursor+1]
+	}
+	j.entries = append(j.entries, JumpEntry{Path: path, IsDoc: isDoc})
+	j.cursor = len(j.entries) - 1
+}
+
+func (j *Jumplist) Back() (JumpEntry, bool) {
+	if j.cursor <= 0 {
+		return JumpEntry{}, false
+	}
+	j.cursor--
+	return j.entries[j.cursor], true
+}
+
+func (j *Jumplist) Forward() (JumpEntry, bool) {
+	if j.cursor >= len(j.entries)-1 {
+		return JumpEntry{}, false
+	}
+	j.cursor++
+	return j.entries[j.cursor], true
+}
+
+func (j *Jumplist) Len() int {
+	return len(j.entries)
+}
+
+func (j *Jumplist) Cursor() int {
+	return j.cursor
+}

--- a/pkg/cmd/browse/jumplist_test.go
+++ b/pkg/cmd/browse/jumplist_test.go
@@ -1,0 +1,107 @@
+package browse
+
+import (
+	"testing"
+)
+
+func TestJumplistPushAndBack(t *testing.T) {
+	j := NewJumplist()
+	j.Push("/users", false)
+	j.Push("/users/abc", true)
+	j.Push("/orders", false)
+
+	entry, ok := j.Back()
+	if !ok {
+		t.Fatal("expected back to succeed")
+	}
+	if entry.Path != "/users/abc" {
+		t.Errorf("expected /users/abc, got %s", entry.Path)
+	}
+
+	entry, ok = j.Back()
+	if !ok {
+		t.Fatal("expected back to succeed")
+	}
+	if entry.Path != "/users" {
+		t.Errorf("expected /users, got %s", entry.Path)
+	}
+}
+
+func TestJumplistForward(t *testing.T) {
+	j := NewJumplist()
+	j.Push("/a", false)
+	j.Push("/b", false)
+	j.Push("/c", false)
+
+	j.Back()
+	j.Back()
+
+	entry, ok := j.Forward()
+	if !ok {
+		t.Fatal("expected forward to succeed")
+	}
+	if entry.Path != "/b" {
+		t.Errorf("expected /b, got %s", entry.Path)
+	}
+
+	entry, ok = j.Forward()
+	if !ok {
+		t.Fatal("expected forward to succeed")
+	}
+	if entry.Path != "/c" {
+		t.Errorf("expected /c, got %s", entry.Path)
+	}
+}
+
+func TestJumplistBoundary(t *testing.T) {
+	j := NewJumplist()
+
+	_, ok := j.Back()
+	if ok {
+		t.Error("expected back on empty jumplist to fail")
+	}
+
+	j.Push("/a", false)
+	_, ok = j.Back()
+	if ok {
+		t.Error("expected back at beginning to fail")
+	}
+
+	_, ok = j.Forward()
+	if ok {
+		t.Error("expected forward at end to fail")
+	}
+}
+
+func TestJumplistTruncation(t *testing.T) {
+	j := NewJumplist()
+	j.Push("/a", false)
+	j.Push("/b", false)
+	j.Push("/c", false)
+
+	j.Back()
+	j.Back()
+	// Now at /a, forward history is /b, /c
+	// Push new path should truncate /b, /c
+	j.Push("/d", false)
+
+	if j.Len() != 2 {
+		t.Errorf("expected 2 entries after truncation, got %d", j.Len())
+	}
+
+	_, ok := j.Forward()
+	if ok {
+		t.Error("expected forward after truncation to fail")
+	}
+}
+
+func TestJumplistPushIsDoc(t *testing.T) {
+	j := NewJumplist()
+	j.Push("/users", false)
+	j.Push("/users/abc", true)
+
+	entry, _ := j.Back()
+	if entry.IsDoc {
+		t.Error("expected /users to not be a doc")
+	}
+}

--- a/pkg/cmd/browse/model.go
+++ b/pkg/cmd/browse/model.go
@@ -86,6 +86,9 @@ type Model struct {
 	marks       map[rune]markEntry
 	pendingMark string // "m" or "'" when waiting for next key
 
+	// Jumplist
+	jumplist *Jumplist
+
 	// Delete confirmation
 	deletePath        string // Path of document pending deletion
 	deleteFromDocView bool   // Whether delete was initiated from a document column

--- a/pkg/cmd/browse/root.go
+++ b/pkg/cmd/browse/root.go
@@ -116,6 +116,7 @@ Examples:
 				pageLimit:       50,
 				selection:       NewSelection(),
 				marks:           make(map[rune]markEntry),
+				jumplist:        NewJumplist(),
 			}
 
 			// Run TUI

--- a/pkg/cmd/browse/update.go
+++ b/pkg/cmd/browse/update.go
@@ -33,6 +33,28 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.textInput.Focus()
 				return m, textinput.Blink
 			}
+			if msg.String() == "ctrl+o" {
+				entry, ok := m.jumplist.Back()
+				if ok {
+					m.columns = []Column{{path: entry.Path, isDoc: entry.IsDoc, scrollOffset: 0}}
+					m.activeColumn = 0
+					m.loading = true
+					sortField, sortDir := m.getSortParams(entry.Path)
+					return m, fetchColumnData(m.client, entry.Path, entry.IsDoc, 0, sortField, sortDir, withLimit(m.pageLimit))
+				}
+				return m, nil
+			}
+			if msg.String() == "ctrl+i" {
+				entry, ok := m.jumplist.Forward()
+				if ok {
+					m.columns = []Column{{path: entry.Path, isDoc: entry.IsDoc, scrollOffset: 0}}
+					m.activeColumn = 0
+					m.loading = true
+					sortField, sortDir := m.getSortParams(entry.Path)
+					return m, fetchColumnData(m.client, entry.Path, entry.IsDoc, 0, sortField, sortDir, withLimit(m.pageLimit))
+				}
+				return m, nil
+			}
 			// Enter filter mode
 			if msg.String() == "/" {
 				m.overlay = OverlayFilter
@@ -322,6 +344,11 @@ func (m Model) handleKeyPress(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				m.statusMsgTime = time.Now()
 				return m, clearStatusAfterDelay()
 			}
+			// Push current location to jumplist
+			if m.activeColumn < len(m.columns) {
+				cur := m.columns[m.activeColumn]
+				m.jumplist.Push(cur.path, cur.isDoc)
+			}
 			m.columns = []Column{{path: mark.path, isDoc: mark.isDoc, scrollOffset: 0}}
 			m.activeColumn = 0
 			m.loading = true
@@ -404,6 +431,11 @@ func (m Model) handleKeyPress(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			}
 
 			logDebug("Adding column: path='%s', isDoc=%v", item.path, item.isDoc)
+			// Push current path to jumplist before navigating forward
+			if m.activeColumn < len(m.columns) {
+				cur := m.columns[m.activeColumn]
+				m.jumplist.Push(cur.path, cur.isDoc)
+			}
 			m.addColumn(item.path, item.isDoc)
 			m.loading = true
 			logDebug("Fetching data for column %d", len(m.columns)-1)


### PR DESCRIPTION
## Summary
- Every forward navigation pushes current path to jumplist
- Ctrl+o navigates backward in history
- Ctrl+i navigates forward in history
- :goto and mark jumps also push to jumplist
- New navigation from mid-history truncates forward entries
- Unit tests cover push, back, forward, truncation, and boundaries

## Test plan
- [ ] Navigate forward through collections, Ctrl+o goes back
- [ ] Ctrl+i goes forward after going back
- [ ] All 26 unit tests pass

Closes #26