### PR TITLE
feat(browse): add server-side Firestore query via :query

### DIFF
--- a/pkg/cmd/browse/command.go
+++ b/pkg/cmd/browse/command.go
@@ -131,6 +131,13 @@ func initCommandRegistry() *CommandRegistry {
 		Handler:     cmdMarks,
 	})
 
+	r.Register(Command{
+		Name:        "query",
+		Description: "Filter collection with a Firestore query",
+		Usage:       ":query <field> <op> <value>",
+		Handler:     cmdQuery,
+	})
+
 	return r
 }
 
@@ -180,6 +187,7 @@ func cmdRefresh(m *Model, args []string) (string, error) {
 	}
 
 	col := m.columns[m.activeColumn]
+	m.columns[m.activeColumn].activeQuery = nil
 	m.loading = true
 
 	sortField, sortDir := m.getSortParams(col.path)
@@ -228,6 +236,34 @@ func cmdSort(m *Model, args []string) (string, error) {
 		dirStr = "Descending"
 	}
 	return fmt.Sprintf("Sorted by %s (%s)", field, dirStr), nil
+}
+
+func cmdQuery(m *Model, args []string) (string, error) {
+	if m.activeColumn >= len(m.columns) {
+		return "", fmt.Errorf("no active column")
+	}
+
+	col := m.columns[m.activeColumn]
+	if col.isDoc {
+		return "", fmt.Errorf("can only query collections, not documents")
+	}
+
+	q, err := ParseQueryArgs(args)
+	if err != nil {
+		return "", err
+	}
+
+	m.columns[m.activeColumn].activeQuery = &q
+	m.loading = true
+
+	sortField, sortDir := m.getSortParams(col.path)
+	m.pendingFetch = &pendingFetchCmd{
+		path: col.path, isDoc: col.isDoc, colIndex: m.activeColumn,
+		sortField: sortField, sortDir: sortDir,
+		opts: []fetchOption{withLimit(m.pageLimit), withQuery(&q)},
+	}
+
+	return fmt.Sprintf("Query: %s", q.String()), nil
 }
 
 func cmdMarks(m *Model, args []string) (string, error) {

--- a/pkg/cmd/browse/firestore.go
+++ b/pkg/cmd/browse/firestore.go
@@ -96,6 +96,7 @@ type fetchOpts struct {
 	limit       int
 	offset      int
 	appendItems bool
+	query       *QueryParam
 }
 
 type fetchOption func(*fetchOpts)
@@ -110,6 +111,10 @@ func withOffset(n int) fetchOption {
 
 func withAppend() fetchOption {
 	return func(o *fetchOpts) { o.appendItems = true }
+}
+
+func withQuery(q *QueryParam) fetchOption {
+	return func(o *fetchOpts) { o.query = q }
 }
 
 type bulkDeletedMsg struct {
@@ -191,6 +196,9 @@ func fetchColumnData(client *firestore.Client, path string, isDoc bool, columnIn
 
 			// Apply sorting if specified
 			query := colRef.Query
+			if fo.query != nil {
+				query = query.Where(fo.query.Field, fo.query.Operator, fo.query.Value)
+			}
 			if sortField != "" {
 				query = query.OrderBy(sortField, sortDirection)
 			}

--- a/pkg/cmd/browse/model.go
+++ b/pkg/cmd/browse/model.go
@@ -120,6 +120,7 @@ type Column struct {
 	scrollOffset    int                    // Scroll position for lists
 	hasMore         bool                   // true if more pages available
 	docCount        int                    // total document count loaded so far
+	activeQuery     *QueryParam            // active server-side query filter
 }
 
 // Section represents a section within a column (Documents or Subcollections)

--- a/pkg/cmd/browse/query.go
+++ b/pkg/cmd/browse/query.go
@@ -1,0 +1,89 @@
+package browse
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+type QueryParam struct {
+	Field    string
+	Operator string
+	Value    interface{}
+}
+
+func (q QueryParam) String() string {
+	switch v := q.Value.(type) {
+	case string:
+		return fmt.Sprintf("%s %s %q", q.Field, q.Operator, v)
+	default:
+		return fmt.Sprintf("%s %s %v", q.Field, q.Operator, q.Value)
+	}
+}
+
+var validOperators = map[string]bool{
+	"==": true, "!=": true,
+	"<": true, ">": true,
+	"<=": true, ">=": true,
+	"array-contains": true, "in": true,
+}
+
+// ParseQueryArgs parses :query arguments into a QueryParam.
+func ParseQueryArgs(args []string) (QueryParam, error) {
+	if len(args) < 3 {
+		return QueryParam{}, fmt.Errorf("usage: :query <field> <op> <value>")
+	}
+
+	field := args[0]
+	op := args[1]
+
+	if !validOperators[op] {
+		return QueryParam{}, fmt.Errorf("invalid operator %q, use: ==, !=, <, >, <=, >=, array-contains, in", op)
+	}
+
+	valueStr := strings.Join(args[2:], " ")
+	value, err := ParseValue(valueStr)
+	if err != nil {
+		return QueryParam{}, fmt.Errorf("invalid value: %w", err)
+	}
+
+	return QueryParam{Field: field, Operator: op, Value: value}, nil
+}
+
+// ParseValue detects the type of a value string and returns the Go representation.
+func ParseValue(s string) (interface{}, error) {
+	s = strings.TrimSpace(s)
+
+	if s == "true" {
+		return true, nil
+	}
+	if s == "false" {
+		return false, nil
+	}
+
+	// Quoted string
+	if len(s) >= 2 && s[0] == '"' && s[len(s)-1] == '"' {
+		var v string
+		if err := json.Unmarshal([]byte(s), &v); err != nil {
+			return nil, err
+		}
+		return v, nil
+	}
+
+	// JSON array
+	if len(s) >= 2 && s[0] == '[' {
+		var arr []interface{}
+		if err := json.Unmarshal([]byte(s), &arr); err != nil {
+			return nil, fmt.Errorf("invalid array: %w", err)
+		}
+		return arr, nil
+	}
+
+	// Number
+	if n, err := strconv.ParseFloat(s, 64); err == nil {
+		return n, nil
+	}
+
+	return nil, fmt.Errorf("unrecognized value %q — use quotes for strings", s)
+}

--- a/pkg/cmd/browse/query_test.go
+++ b/pkg/cmd/browse/query_test.go
@@ -1,0 +1,116 @@
+package browse
+
+import (
+	"testing"
+)
+
+func TestParseValue(t *testing.T) {
+	tests := []struct {
+		input string
+		want  interface{}
+	}{
+		{`"active"`, "active"},
+		{`"hello world"`, "hello world"},
+		{`42`, float64(42)},
+		{`3.14`, float64(3.14)},
+		{`true`, true},
+		{`false`, false},
+		{`["a","b","c"]`, []interface{}{"a", "b", "c"}},
+		{`[1,2,3]`, []interface{}{float64(1), float64(2), float64(3)}},
+	}
+
+	for _, tt := range tests {
+		got, err := ParseValue(tt.input)
+		if err != nil {
+			t.Errorf("ParseValue(%q) error: %v", tt.input, err)
+			continue
+		}
+
+		switch expected := tt.want.(type) {
+		case string:
+			if got != expected {
+				t.Errorf("ParseValue(%q) = %v, want %v", tt.input, got, expected)
+			}
+		case float64:
+			if got != expected {
+				t.Errorf("ParseValue(%q) = %v, want %v", tt.input, got, expected)
+			}
+		case bool:
+			if got != expected {
+				t.Errorf("ParseValue(%q) = %v, want %v", tt.input, got, expected)
+			}
+		case []interface{}:
+			gotArr, ok := got.([]interface{})
+			if !ok {
+				t.Errorf("ParseValue(%q) not an array", tt.input)
+				continue
+			}
+			if len(gotArr) != len(expected) {
+				t.Errorf("ParseValue(%q) array len = %d, want %d", tt.input, len(gotArr), len(expected))
+			}
+		}
+	}
+}
+
+func TestParseValueErrors(t *testing.T) {
+	tests := []string{
+		"unquoted",
+		"[invalid",
+	}
+
+	for _, input := range tests {
+		_, err := ParseValue(input)
+		if err == nil {
+			t.Errorf("ParseValue(%q) expected error", input)
+		}
+	}
+}
+
+func TestParseQueryArgs(t *testing.T) {
+	tests := []struct {
+		args     []string
+		wantOp   string
+		wantErr  bool
+	}{
+		{[]string{"status", "==", `"active"`}, "==", false},
+		{[]string{"count", ">", "10"}, ">", false},
+		{[]string{"active", "==", "true"}, "==", false},
+		{[]string{"tags", "array-contains", `"urgent"`}, "array-contains", false},
+		{[]string{"status", "in", `["active","pending"]`}, "in", false},
+		{[]string{"field"}, "", true},
+		{[]string{"field", "INVALID", "val"}, "", true},
+	}
+
+	for _, tt := range tests {
+		q, err := ParseQueryArgs(tt.args)
+		if tt.wantErr {
+			if err == nil {
+				t.Errorf("ParseQueryArgs(%v) expected error", tt.args)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("ParseQueryArgs(%v) error: %v", tt.args, err)
+			continue
+		}
+		if q.Operator != tt.wantOp {
+			t.Errorf("ParseQueryArgs(%v) op = %q, want %q", tt.args, q.Operator, tt.wantOp)
+		}
+	}
+}
+
+func TestQueryParamString(t *testing.T) {
+	q := QueryParam{Field: "status", Operator: "==", Value: "active"}
+	got := q.String()
+	want := `status == "active"`
+	if got != want {
+		t.Errorf("String() = %q, want %q", got, want)
+	}
+
+	q2 := QueryParam{Field: "count", Operator: ">", Value: float64(10)}
+	got2 := q2.String()
+	want2 := "count > 10"
+	if got2 != want2 {
+		t.Errorf("String() = %q, want %q", got2, want2)
+	}
+}

--- a/pkg/cmd/browse/view.go
+++ b/pkg/cmd/browse/view.go
@@ -674,12 +674,15 @@ func (m Model) getFooterHints() string {
 func (m Model) renderStatusBar() string {
 	var parts []string
 
-	// Show pagination info for active collection column
+	// Show pagination info and active query for active collection column
 	if m.activeColumn < len(m.columns) {
 		col := m.columns[m.activeColumn]
 		if !col.isDoc && col.docCount > 0 {
 			info := fmt.Sprintf("%d docs | limit: %d", col.docCount, m.pageLimit)
 			parts = append(parts, info)
+		}
+		if col.activeQuery != nil {
+			parts = append(parts, "Query: "+col.activeQuery.String())
 		}
 	}
 


### PR DESCRIPTION
## Summary
- `:query <field> <op> <value>` constructs Firestore .Where() queries
- Supports all operators: ==, !=, <, >, <=, >=, array-contains, in
- Automatic type detection: quoted strings, numbers, booleans, JSON arrays
- Active query shown in status bar
- `:refresh` clears active query
- Firestore errors (including index URLs) displayed in full
- Unit tests cover value parsing, query parsing, and string representation

## Test plan
- [ ] `:query status == "active"` filters collection
- [ ] All operators work correctly
- [ ] Status bar shows active query
- [ ] `:refresh` clears query
- [ ] All 30 tests pass

Closes #27