### PR TITLE
feat(browse): add toggleable document preview pane

### DIFF
--- a/pkg/cmd/browse/model.go
+++ b/pkg/cmd/browse/model.go
@@ -89,6 +89,13 @@ type Model struct {
 	// Jumplist
 	jumplist *Jumplist
 
+	// Preview pane
+	previewEnabled bool
+	previewPath    string
+	previewData    map[string]interface{}
+	previewNodes   []ListItem
+	previewPending string // path of pending debounced fetch
+
 	// Delete confirmation
 	deletePath        string // Path of document pending deletion
 	deleteFromDocView bool   // Whether delete was initiated from a document column
@@ -184,6 +191,15 @@ type documentUpdatedMsg struct {
 type documentDeletedMsg struct {
 	path        string
 	fromDocView bool // true if delete was initiated from a document column
+}
+
+type previewDebounceMsg struct {
+	path string
+}
+
+type previewFetchedMsg struct {
+	path string
+	data map[string]interface{}
 }
 
 // getSortParams returns the saved sort field and direction for a given path

--- a/pkg/cmd/browse/styles.go
+++ b/pkg/cmd/browse/styles.go
@@ -160,4 +160,10 @@ var (
 				Bold(true).
 				Foreground(lipgloss.Color("0")).
 				Background(colorYellow)
+
+	// Preview pane style
+	previewStyle = lipgloss.NewStyle().
+			Border(lipgloss.RoundedBorder()).
+			BorderForeground(colorGreen).
+			Padding(0, 1)
 )

--- a/pkg/cmd/browse/update.go
+++ b/pkg/cmd/browse/update.go
@@ -1,6 +1,7 @@
 package browse
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -262,6 +263,28 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, handleEditorFinished(msg.session)
 
+	case previewDebounceMsg:
+		if !m.previewEnabled || msg.path != m.previewPending {
+			return m, nil
+		}
+		if msg.path == m.previewPath {
+			return m, nil
+		}
+		return m, fetchPreviewData(m.client, msg.path)
+
+	case previewFetchedMsg:
+		if !m.previewEnabled {
+			return m, nil
+		}
+		m.previewPath = msg.path
+		m.previewData = msg.data
+		if msg.data != nil {
+			m.previewNodes = buildTreeNodes(msg.data)
+		} else {
+			m.previewNodes = nil
+		}
+		return m, nil
+
 	case bulkDeletedMsg:
 		m.loading = false
 		m.statusMsg = fmt.Sprintf("%d documents deleted", msg.count)
@@ -371,11 +394,11 @@ func (m Model) handleKeyPress(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	// Vertical navigation (within column)
 	case "j", "down":
 		m.moveCursor(1)
-		return m, nil
+		return m, m.schedulePreviewFetch()
 
 	case "k", "up":
 		m.moveCursor(-1)
-		return m, nil
+		return m, m.schedulePreviewFetch()
 
 	case "g":
 		m.jumpToTop()
@@ -495,6 +518,18 @@ func (m Model) handleKeyPress(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			fetchColumnData(m.client, col.path, col.isDoc, m.activeColumn, "", 0, withLimit(m.pageLimit)),
 			clearStatusAfterDelay(),
 		)
+
+	case "p":
+		m.previewEnabled = !m.previewEnabled
+		if !m.previewEnabled {
+			m.previewPath = ""
+			m.previewData = nil
+			m.previewNodes = nil
+			m.previewPending = ""
+		} else {
+			return m, m.schedulePreviewFetch()
+		}
+		return m, nil
 
 	case "e":
 		// Edit document
@@ -917,6 +952,37 @@ func (m Model) handleVisualMode(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	}
 
 	return m, nil
+}
+
+func (m *Model) schedulePreviewFetch() tea.Cmd {
+	if !m.previewEnabled {
+		return nil
+	}
+	item := m.getSelectedItem()
+	if item == nil || !item.isDoc || item.path == "__load_more__" {
+		m.previewPending = ""
+		return nil
+	}
+	m.previewPending = item.path
+	path := item.path
+	return tea.Tick(300*time.Millisecond, func(time.Time) tea.Msg {
+		return previewDebounceMsg{path: path}
+	})
+}
+
+func fetchPreviewData(client *firestore.Client, path string) tea.Cmd {
+	return func() tea.Msg {
+		ctx := context.Background()
+		docRef := client.Doc(strings.TrimPrefix(path, "/"))
+		snap, err := docRef.Get(ctx)
+		if err != nil {
+			return previewFetchedMsg{path: path, data: nil}
+		}
+		if !snap.Exists() {
+			return previewFetchedMsg{path: path, data: nil}
+		}
+		return previewFetchedMsg{path: path, data: snap.Data()}
+	}
 }
 
 func longestCommonPrefix(strs []string) string {

--- a/pkg/cmd/browse/view.go
+++ b/pkg/cmd/browse/view.go
@@ -245,17 +245,30 @@ func (m Model) renderColumns() string {
 	}
 
 	visibleCols := getVisibleColumns(m.columns, m.activeColumn)
-	colWidth := calculateColumnWidth(m.width, len(visibleCols))
-	logDebug("renderColumns: visibleCols=%d, colWidth=%d", len(visibleCols), colWidth)
+
+	// Calculate column width, reserving space for preview if enabled
+	previewWidth := 0
+	totalWidth := m.width
+	if m.previewEnabled && len(m.previewNodes) > 0 {
+		previewWidth = totalWidth / 3
+		totalWidth -= previewWidth
+	}
+	colWidth := calculateColumnWidth(totalWidth, len(visibleCols))
+	logDebug("renderColumns: visibleCols=%d, colWidth=%d, previewWidth=%d", len(visibleCols), colWidth, previewWidth)
 
 	var renderedCols []string
 	for i, col := range visibleCols {
-		// Determine if this is the active column
 		isActive := (i == m.activeColumn) || (len(m.columns) > 4 && i == 3)
 
 		rendered := m.renderColumn(col, colWidth, isActive)
 		logDebug("renderColumns: column %d rendered, length=%d", i, len(rendered))
 		renderedCols = append(renderedCols, rendered)
+	}
+
+	// Add preview pane if enabled
+	if m.previewEnabled && previewWidth > 0 && len(m.previewNodes) > 0 {
+		previewCol := m.renderPreviewPane(previewWidth)
+		renderedCols = append(renderedCols, previewCol)
 	}
 
 	logDebug("renderColumns: about to JoinHorizontal with %d columns", len(renderedCols))
@@ -645,6 +658,38 @@ func (m Model) renderColumn(col Column, width int, isActive bool) string {
 	return result
 }
 
+func (m Model) renderPreviewPane(width int) string {
+	height := m.height - 5 - 2
+	if height < 1 {
+		height = 10
+	}
+
+	innerWidth := max(width-4, 1)
+	var content strings.Builder
+
+	// Title
+	parts := strings.Split(m.previewPath, "/")
+	title := m.previewPath
+	if len(parts) > 0 {
+		title = parts[len(parts)-1]
+	}
+	content.WriteString(sectionHeaderStyle.Render("Preview: " + title))
+	content.WriteString("\n")
+
+	wrapper := lipgloss.NewStyle().Width(innerWidth)
+	itemIndex := 0
+	m.renderTreeNodes(m.previewNodes, 0, -1, &itemIndex, &content, wrapper, innerWidth)
+
+	columnContent := content.String()
+	lines := strings.Split(columnContent, "\n")
+	if len(lines) > height {
+		lines = lines[:height]
+	}
+	columnContent = strings.Join(lines, "\n")
+
+	return previewStyle.Width(width).Height(height).Render(columnContent)
+}
+
 // getFooterHints returns context-sensitive keybinding hints
 func (m Model) getFooterHints() string {
 	if m.overlay == OverlaySortDialog {
@@ -689,6 +734,11 @@ func (m Model) renderStatusBar() string {
 	// Show active filter
 	if m.filterActive && m.filterPattern != "" {
 		parts = append(parts, "Filter: "+m.filterPattern)
+	}
+
+	// Show preview mode
+	if m.previewEnabled {
+		parts = append(parts, "Preview: ON")
 	}
 
 	if len(parts) > 0 {


### PR DESCRIPTION
## Summary
- `p` toggles preview mode on/off
- Preview pane renders alongside columns (1/3 width)
- Document fetches debounced at 300ms to control read costs
- Preview shows tree view of document data (read-only)
- Status bar shows "Preview: ON" when active
- Only activates for document items in collection columns

## Test plan
- [ ] `p` toggles preview pane
- [ ] Preview shows document content when cursor on a document
- [ ] Moving cursor quickly doesn't trigger excessive fetches
- [ ] All 30 tests pass

Closes #28