### PR TITLE
feat(browse): add tree fold controls (zM, zR, z1-z3)

### DIFF
--- a/pkg/cmd/browse/model.go
+++ b/pkg/cmd/browse/model.go
@@ -89,6 +89,9 @@ type Model struct {
 	// Jumplist
 	jumplist *Jumplist
 
+	// Tree fold
+	pendingZKey bool
+
 	// Preview pane
 	previewEnabled bool
 	previewPath    string

--- a/pkg/cmd/browse/navigation.go
+++ b/pkg/cmd/browse/navigation.go
@@ -402,3 +402,56 @@ func getVisibleColumns(columns []Column, activeColumn int) []Column {
 
 	return columns[start:]
 }
+
+func (m *Model) foldAll(expand bool) {
+	if m.activeColumn >= len(m.columns) {
+		return
+	}
+	col := &m.columns[m.activeColumn]
+	if !col.isDoc {
+		return
+	}
+	for i := range col.sections {
+		if col.sections[i].title == "Data" {
+			setExpandAll(col.sections[i].items, expand)
+		}
+	}
+}
+
+func (m *Model) foldToDepth(maxDepth int) {
+	if m.activeColumn >= len(m.columns) {
+		return
+	}
+	col := &m.columns[m.activeColumn]
+	if !col.isDoc {
+		return
+	}
+	for i := range col.sections {
+		if col.sections[i].title == "Data" {
+			setExpandToDepth(col.sections[i].items, 0, maxDepth)
+		}
+	}
+	// Reset cursor if it would be on a hidden node
+	totalItems := m.getAllItemsCount(*col)
+	if col.cursor >= totalItems && totalItems > 0 {
+		col.cursor = totalItems - 1
+	}
+}
+
+func setExpandAll(items []ListItem, expand bool) {
+	for i := range items {
+		items[i].expanded = expand
+		if len(items[i].children) > 0 {
+			setExpandAll(items[i].children, expand)
+		}
+	}
+}
+
+func setExpandToDepth(items []ListItem, currentDepth int, maxDepth int) {
+	for i := range items {
+		items[i].expanded = currentDepth < maxDepth
+		if len(items[i].children) > 0 {
+			setExpandToDepth(items[i].children, currentDepth+1, maxDepth)
+		}
+	}
+}

--- a/pkg/cmd/browse/update.go
+++ b/pkg/cmd/browse/update.go
@@ -342,6 +342,24 @@ func (m Model) handleKeyPress(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.handleCopyAlternate()
 	}
 
+	// Handle pending z-key for fold controls
+	if m.pendingZKey {
+		m.pendingZKey = false
+		switch currentKey {
+		case "M":
+			m.foldAll(false)
+		case "R":
+			m.foldAll(true)
+		case "1":
+			m.foldToDepth(1)
+		case "2":
+			m.foldToDepth(2)
+		case "3":
+			m.foldToDepth(3)
+		}
+		return m, nil
+	}
+
 	// Handle pending mark operations
 	if m.pendingMark == "m" {
 		m.pendingMark = ""
@@ -518,6 +536,10 @@ func (m Model) handleKeyPress(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			fetchColumnData(m.client, col.path, col.isDoc, m.activeColumn, "", 0, withLimit(m.pageLimit)),
 			clearStatusAfterDelay(),
 		)
+
+	case "z":
+		m.pendingZKey = true
+		return m, nil
 
 	case "p":
 		m.previewEnabled = !m.previewEnabled


### PR DESCRIPTION
## Summary
- `zM` collapses all tree nodes
- `zR` expands all tree nodes
- `z1`/`z2`/`z3` expand to specific depth levels
- `z` prefix waits for next key (M, R, 1, 2, 3)
- Only operates on document columns with Data sections
- Cursor position preserved or reset if on hidden node

## Test plan
- [ ] `zM` collapses all nodes
- [ ] `zR` expands all nodes
- [ ] `z1`-`z3` expand to correct depth
- [ ] All 30 tests pass

Closes #29