### PR TITLE
feat(browse): add document creation with :add command

### DIFF
--- a/pkg/cmd/browse/command.go
+++ b/pkg/cmd/browse/command.go
@@ -138,6 +138,13 @@ func initCommandRegistry() *CommandRegistry {
 		Handler:     cmdQuery,
 	})
 
+	r.Register(Command{
+		Name:        "add",
+		Description: "Create a new document in the current collection",
+		Usage:       ":add [id]",
+		Handler:     cmdAdd,
+	})
+
 	return r
 }
 
@@ -236,6 +243,25 @@ func cmdSort(m *Model, args []string) (string, error) {
 		dirStr = "Descending"
 	}
 	return fmt.Sprintf("Sorted by %s (%s)", field, dirStr), nil
+}
+
+func cmdAdd(m *Model, args []string) (string, error) {
+	if m.activeColumn >= len(m.columns) {
+		return "", fmt.Errorf("no active column")
+	}
+
+	col := m.columns[m.activeColumn]
+	if col.isDoc {
+		return "", fmt.Errorf("can only add documents to collections")
+	}
+
+	docID := ""
+	if len(args) > 0 {
+		docID = args[0]
+	}
+
+	m.pendingEditor = startAddCmd(m.client, col.path, docID, col.availableFields, m.activeColumn)
+	return "", nil
 }
 
 func cmdQuery(m *Model, args []string) (string, error) {

--- a/pkg/cmd/browse/editor.go
+++ b/pkg/cmd/browse/editor.go
@@ -14,10 +14,13 @@ import (
 
 // editSession holds state for an ongoing edit session
 type editSession struct {
-	client   *firestore.Client
-	docPath  string
-	tempFile string
-	editor   string
+	client     *firestore.Client
+	docPath    string
+	tempFile   string
+	editor     string
+	isCreate   bool   // true when creating a new document
+	colPath    string // collection path (for create mode)
+	colIndex   int    // column index to refresh after create
 }
 
 // detectEditor finds the user's preferred editor
@@ -150,6 +153,67 @@ func openEditorCmd(session editSession) tea.Cmd {
 	})
 }
 
+// generateTemplate creates a JSON template from the first document's field structure
+func generateTemplate(sections []Section) string {
+	for _, s := range sections {
+		if s.title == "Documents" && len(s.items) > 0 {
+			// We can't derive the template from ListItems directly since they don't have full data.
+			// The template will be based on available fields from the column.
+			break
+		}
+	}
+	return "{}"
+}
+
+// generateTemplateFromFields creates a JSON template with null values for each field
+func generateTemplateFromFields(fields []string) string {
+	if len(fields) == 0 {
+		return "{}"
+	}
+	data := make(map[string]interface{})
+	for _, f := range fields {
+		data[f] = nil
+	}
+	jsonBytes, err := json.MarshalIndent(data, "", "  ")
+	if err != nil {
+		return "{}"
+	}
+	return string(jsonBytes)
+}
+
+// startAddCmd initializes a create session and launches the editor
+func startAddCmd(client *firestore.Client, colPath string, docID string, availableFields []string, colIndex int) tea.Cmd {
+	return func() tea.Msg {
+		editor, err := detectEditor()
+		if err != nil {
+			return errorMsg{err: err}
+		}
+
+		template := generateTemplateFromFields(availableFields)
+
+		tempFile, err := createTempFile(template)
+		if err != nil {
+			return errorMsg{err: err}
+		}
+
+		session := editSession{
+			client:   client,
+			docPath:  colPath + "/" + docID,
+			tempFile: tempFile,
+			editor:   editor,
+			isCreate: true,
+			colPath:  colPath,
+			colIndex: colIndex,
+		}
+
+		if docID == "" {
+			session.docPath = ""
+		}
+
+		return launchEditorMsg{session: session}
+	}
+}
+
 // handleEditorFinished processes the result after editor closes
 func handleEditorFinished(session editSession) tea.Cmd {
 	return func() tea.Msg {
@@ -167,19 +231,48 @@ func handleEditorFinished(session editSession) tea.Cmd {
 			return launchEditorMsg{session: session}
 		}
 
-		// Valid JSON - save to Firestore
 		ctx := context.Background()
+
+		if session.isCreate {
+			// Create new document
+			var docRef *firestore.DocumentRef
+			colRef := session.client.Collection(strings.TrimPrefix(session.colPath, "/"))
+
+			if session.docPath == "" {
+				// Auto-generated ID
+				docRef = colRef.NewDoc()
+			} else {
+				// Custom ID
+				parts := strings.Split(session.docPath, "/")
+				docID := parts[len(parts)-1]
+				docRef = colRef.Doc(docID)
+			}
+
+			_, err = docRef.Set(ctx, newData)
+
+			os.Remove(session.tempFile)
+
+			if err != nil {
+				return errorMsg{err: fmt.Errorf("failed to create document: %w", err)}
+			}
+
+			return documentCreatedMsg{
+				colPath:  session.colPath,
+				docID:    docRef.ID,
+				colIndex: session.colIndex,
+			}
+		}
+
+		// Update existing document
 		docRef := session.client.Doc(strings.TrimPrefix(session.docPath, "/"))
 		_, err = docRef.Set(ctx, newData)
 
-		// Clean up temp file
 		os.Remove(session.tempFile)
 
 		if err != nil {
 			return errorMsg{err: fmt.Errorf("failed to save document: %w", err)}
 		}
 
-		// Return success message
 		return documentUpdatedMsg{
 			path: session.docPath,
 			data: newData,

--- a/pkg/cmd/browse/model.go
+++ b/pkg/cmd/browse/model.go
@@ -65,6 +65,7 @@ type Model struct {
 	commandInput    textinput.Model
 	commandResult   string
 	pendingFetch    *pendingFetchCmd
+	pendingEditor   tea.Cmd
 
 	// Sort dialog
 	sortDialog sortDialogModel
@@ -194,6 +195,12 @@ type documentUpdatedMsg struct {
 type documentDeletedMsg struct {
 	path        string
 	fromDocView bool // true if delete was initiated from a document column
+}
+
+type documentCreatedMsg struct {
+	colPath  string
+	docID    string
+	colIndex int
 }
 
 type previewDebounceMsg struct {

--- a/pkg/cmd/browse/update.go
+++ b/pkg/cmd/browse/update.go
@@ -285,6 +285,22 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 
+	case documentCreatedMsg:
+		m.loading = false
+		m.statusMsg = fmt.Sprintf("Document created: %s", msg.docID)
+		m.statusMsgTime = time.Now()
+
+		if msg.colIndex < len(m.columns) {
+			col := m.columns[msg.colIndex]
+			sortField, sortDir := m.getSortParams(col.path)
+			m.loading = true
+			return m, tea.Batch(
+				fetchColumnData(m.client, col.path, col.isDoc, msg.colIndex, sortField, sortDir, withLimit(m.pageLimit)),
+				clearStatusAfterDelay(),
+			)
+		}
+		return m, clearStatusAfterDelay()
+
 	case bulkDeletedMsg:
 		m.loading = false
 		m.statusMsg = fmt.Sprintf("%d documents deleted", msg.count)
@@ -849,6 +865,13 @@ func (m Model) handleCommandMode(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if statusText != "" {
 			m.statusMsg = statusText
 			m.statusMsgTime = time.Now()
+		}
+
+		// Check if the handler set a pending editor launch
+		if m.pendingEditor != nil {
+			cmd := m.pendingEditor
+			m.pendingEditor = nil
+			return m, cmd
 		}
 
 		// Check if the handler set a pending fetch


### PR DESCRIPTION
## Summary
- `:add` creates document with Firestore auto-generated ID
- `:add my-id` creates document with custom ID
- Opens $EDITOR with template from first document's fields (null values)
- Template is `{}` when no documents loaded
- Invalid JSON reopens editor with error (existing edit pattern)
- Valid JSON creates document via Firestore .Set() and refreshes collection
- Status bar shows "Document created: <id>" on success
- Error shown when used on document column (not collection)

## Test plan
- [ ] `:add` opens editor and creates document with auto ID
- [ ] `:add my-id` creates document with custom ID
- [ ] Template uses existing field structure
- [ ] Invalid JSON reopens editor
- [ ] Collection refreshes after creation
- [ ] All 30 tests pass

Closes #30