### PR TITLE
feat(browse): modern borderless TUI redesign with UX improvements

### DIFF
--- a/pkg/cmd/browse/command.go
+++ b/pkg/cmd/browse/command.go
@@ -83,6 +83,13 @@ func initCommandRegistry() *CommandRegistry {
 	r := NewCommandRegistry()
 
 	r.Register(Command{
+		Name:        "quit",
+		Description: "Quit the application",
+		Usage:       ":quit",
+		Handler:     cmdQuit,
+	})
+
+	r.Register(Command{
 		Name:        "help",
 		Description: "List all available commands",
 		Usage:       ":help",
@@ -146,6 +153,11 @@ func initCommandRegistry() *CommandRegistry {
 	})
 
 	return r
+}
+
+func cmdQuit(m *Model, args []string) (string, error) {
+	m.pendingQuit = true
+	return "", nil
 }
 
 func cmdHelp(m *Model, args []string) (string, error) {

--- a/pkg/cmd/browse/command.go
+++ b/pkg/cmd/browse/command.go
@@ -90,6 +90,13 @@ func initCommandRegistry() *CommandRegistry {
 	})
 
 	r.Register(Command{
+		Name:        "man",
+		Description: "Show the full manual",
+		Usage:       ":man",
+		Handler:     cmdMan,
+	})
+
+	r.Register(Command{
 		Name:        "help",
 		Description: "List all available commands",
 		Usage:       ":help",
@@ -155,6 +162,116 @@ func initCommandRegistry() *CommandRegistry {
 	return r
 }
 
+func cmdMan(m *Model, args []string) (string, error) {
+	return `FIRESTORE BROWSE — MANUAL
+
+OVERVIEW
+  A vim-style TUI for browsing Firestore databases.
+  Navigate collections and documents using Miller columns.
+
+MODES
+  NORMAL    Default mode. Navigate, view, and operate on data.
+  VISUAL    Select multiple items for bulk operations.
+  COMMAND   Enter commands with : prefix.
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+NAVIGATION
+
+  j / ↓           Move cursor down
+  k / ↑           Move cursor up
+  g               Jump to top of column
+  G               Jump to bottom of column
+  l / → / Enter   Navigate forward (open collection/document)
+  h / ← / Bksp    Navigate back (close column / collapse node)
+  Space           Toggle expand/collapse on tree node
+
+  Ctrl+d / PgDn   Scroll down (half page)
+  Ctrl+u / PgUp   Scroll up (half page)
+
+  Ctrl+g          Go to path (opens path input dialog)
+  /               Filter current column (substring match)
+
+  Ctrl+o          Jump back in history
+  Ctrl+i          Jump forward in history
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+MARKS & BOOKMARKS
+
+  m + [a-z]       Set a mark at current location
+  ' + [a-z]       Jump to a mark
+
+  :marks          List all set marks
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+TREE VIEW CONTROLS
+
+  zM              Fold all (collapse entire tree)
+  zR              Unfold all (expand entire tree)
+  z1              Fold to depth 1
+  z2              Fold to depth 2
+  z3              Fold to depth 3
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+DOCUMENT OPERATIONS
+
+  e               Edit document (opens $EDITOR)
+  d               Delete document (with confirmation)
+  r               Refresh current column
+  p               Toggle preview pane
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+CLIPBOARD / COPY
+
+  yy              Copy selected value (field value or path)
+  ya              Copy entire document as JSON
+  Y               Copy ID or field key
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+SORT & QUERY
+
+  s               Open sort dialog
+  S               Clear sort for current collection
+
+  :sort <f> [dir]       Sort by field (asc/desc)
+  :query <f> <op> <v>   Server-side Firestore query
+                        Operators: ==  !=  <  >  <=  >=
+                                   array-contains  in
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+VISUAL MODE
+
+  v               Toggle item selection / enter visual mode
+  V               Range select (anchor + move to extend)
+  j / k           Move and extend selection
+  d               Bulk delete selected documents
+  Esc             Exit visual mode
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+COMMANDS
+
+  :help                   List available commands
+  :man                    Show this manual
+  :quit                   Quit the application
+  :goto <path>            Navigate to a Firestore path
+  :refresh                Refresh current column
+  :sort <field> [asc|desc]  Sort collection by field
+  :query <f> <op> <val>   Filter with a server-side query
+  :set limit <n>          Set pagination limit (default: 50)
+  :export json|ndjson [f] Export documents (to file or clipboard)
+  :add [id]               Create a new document
+  :marks                  List all bookmarks
+
+  Tab in command mode autocompletes command names.
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+QUITTING
+
+  q               Quit
+  :quit           Quit
+  Ctrl+c          Quit (except in command mode, where it cancels)
+  Esc             Shows "Press q to quit" hint`, nil
+}
+
 func cmdQuit(m *Model, args []string) (string, error) {
 	m.pendingQuit = true
 	return "", nil
@@ -165,7 +282,7 @@ func cmdHelp(m *Model, args []string) (string, error) {
 	for _, cmd := range m.commandRegistry.All() {
 		lines = append(lines, fmt.Sprintf("  %-20s %s", cmd.Usage, cmd.Description))
 	}
-	return "Commands:\n" + strings.Join(lines, "\n"), nil
+	return "Commands:\n" + strings.Join(lines, "\n") + "\n\nType :man for the full manual.", nil
 }
 
 func cmdGoto(m *Model, args []string) (string, error) {

--- a/pkg/cmd/browse/model.go
+++ b/pkg/cmd/browse/model.go
@@ -113,7 +113,8 @@ type Model struct {
 	filterPattern string
 
 	// Info overlay (for :help, :marks, etc.)
-	infoContent string
+	infoContent  string
+	infoViewport viewport.Model
 }
 
 // sortStateEntry stores sort configuration for a collection path

--- a/pkg/cmd/browse/model.go
+++ b/pkg/cmd/browse/model.go
@@ -67,6 +67,7 @@ type Model struct {
 	commandResult   string
 	pendingFetch    *pendingFetchCmd
 	pendingEditor   tea.Cmd
+	pendingQuit     bool
 
 	// Sort dialog
 	sortDialog sortDialogModel

--- a/pkg/cmd/browse/model.go
+++ b/pkg/cmd/browse/model.go
@@ -28,6 +28,7 @@ const (
 	OverlaySortDialog
 	OverlayDeleteConfirm
 	OverlayFilter
+	OverlayInfo
 )
 
 func (m Mode) String() string {
@@ -109,6 +110,9 @@ type Model struct {
 	filterInput   textinput.Model
 	filterActive  bool
 	filterPattern string
+
+	// Info overlay (for :help, :marks, etc.)
+	infoContent string
 }
 
 // sortStateEntry stores sort configuration for a collection path

--- a/pkg/cmd/browse/navigation.go
+++ b/pkg/cmd/browse/navigation.go
@@ -135,6 +135,14 @@ func (m *Model) moveCursor(delta int) {
 	}
 }
 
+func (m *Model) itemViewHeight() int {
+	h := m.height - 7 // outer chrome(5): header, blank, separator, status, footer; column header(2): title, underline
+	if h < 1 {
+		return 10
+	}
+	return h
+}
+
 // autoScroll adjusts scroll offset to keep cursor visible
 func (m *Model) autoScroll() {
 	if m.activeColumn >= len(m.columns) {
@@ -142,16 +150,13 @@ func (m *Model) autoScroll() {
 	}
 
 	col := &m.columns[m.activeColumn]
-	// Match height calculation in view.go: m.height - 5 (header/statusbar/footer/error/margin) - 2 (borders)
-	viewHeight := m.height - 7
-	if viewHeight < 1 {
-		viewHeight = 10
-	}
+	viewHeight := m.itemViewHeight()
 
 	// Calculate column width and inner width (same as in renderColumn)
 	visibleCols := getVisibleColumns(m.columns, m.activeColumn)
-	colWidth := calculateColumnWidth(m.width, len(visibleCols))
-	innerWidth := max(colWidth-4, 1)
+	availWidth := m.width - 4 // 2 padding on each side
+	colWidth := calculateColumnWidth(availWidth, len(visibleCols))
+	innerWidth := max(colWidth-2, 1)
 
 	// Create wrapper for measuring wrapped line lengths
 	wrapper := lipgloss.NewStyle().Width(innerWidth)
@@ -167,8 +172,10 @@ func (m *Model) autoScroll() {
 		if section.hidden {
 			continue
 		}
-		// Section header takes 1 line
-		cursorLine++
+		// Section header takes 1 line (but "Documents" is skipped for collection columns)
+		if section.title != "Documents" || col.isDoc {
+			cursorLine++
+		}
 
 		if section.title == "Data" {
 			// Tree view logic - we need to traverse the tree to find where the cursor lands
@@ -297,19 +304,14 @@ func (m *Model) scrollDown() {
 	}
 
 	col := &m.columns[m.activeColumn]
-	viewHeight := m.height - 7
-	if viewHeight < 1 {
-		viewHeight = 10
-	}
+	viewHeight := m.itemViewHeight()
 
-	pageSize := viewHeight / 2 // Half page scroll
+	pageSize := viewHeight / 2
 	if pageSize < 1 {
 		pageSize = 1
 	}
 
 	col.scrollOffset += pageSize
-	// Upper bound will be checked in renderColumn, but we can't check it here
-	// because we don't know the full content length until render time.
 }
 
 // scrollUp scrolls the active column up by half a page
@@ -319,10 +321,7 @@ func (m *Model) scrollUp() {
 	}
 
 	col := &m.columns[m.activeColumn]
-	viewHeight := m.height - 7
-	if viewHeight < 1 {
-		viewHeight = 10
-	}
+	viewHeight := m.itemViewHeight()
 
 	pageSize := viewHeight / 2 // Half page scroll
 	if pageSize < 1 {
@@ -370,7 +369,6 @@ func (m *Model) removeLastColumn() {
 
 // calculateColumnWidth calculates the width for each column
 func calculateColumnWidth(termWidth int, numColumns int) int {
-	// Show max 4 columns at a time
 	visibleCols := numColumns
 	if visibleCols > 4 {
 		visibleCols = 4
@@ -380,10 +378,11 @@ func calculateColumnWidth(termWidth int, numColumns int) int {
 		return termWidth
 	}
 
-	// Account for borders and padding
-	width := (termWidth - (visibleCols * 4)) / visibleCols
+	// Separators between columns: " │ " = 3 chars each
+	separatorWidth := (visibleCols - 1) * 3
+	width := (termWidth - separatorWidth) / visibleCols
 	if width < 10 {
-		width = 10 // Minimum width
+		width = 10
 	}
 	return width
 }

--- a/pkg/cmd/browse/styles.go
+++ b/pkg/cmd/browse/styles.go
@@ -5,165 +5,186 @@ import (
 )
 
 var (
-	// Colors
-	colorCyan   = lipgloss.Color("86")
-	colorGray   = lipgloss.Color("240")
-	colorGreen  = lipgloss.Color("42")
-	colorBlue   = lipgloss.Color("39")
-	colorRed    = lipgloss.Color("196")
-	colorYellow = lipgloss.Color("220")
+	// Muted/Pastel color palette
+	colorAccent    = lipgloss.Color("75")  // Slate blue — primary accent
+	colorDim       = lipgloss.Color("243") // Gray — inactive/secondary text
+	colorSeparator = lipgloss.Color("238") // Dim gray — structural lines
+	colorHeader    = lipgloss.Color("252") // Near white — column headers
+	colorError     = lipgloss.Color("167") // Soft red
+	colorSuccess   = lipgloss.Color("108") // Sage green
+	colorWarning   = lipgloss.Color("222") // Soft yellow
 
-	// Header style
-	headerStyle = lipgloss.NewStyle().
-			Bold(true).
-			Foreground(colorCyan).
-			Padding(0, 1)
+	// Keep color aliases used by notification overlay in view.go
+	colorGreen = lipgloss.Color("108")
+	colorGray  = lipgloss.Color("243")
 
-	// Footer style
+	// Breadcrumb header
+	headerProjectStyle = lipgloss.NewStyle().
+		Bold(true).
+		Foreground(colorHeader)
+
+	headerSepStyle = lipgloss.NewStyle().
+		Foreground(colorDim)
+
+	headerPathStyle = lipgloss.NewStyle().
+		Foreground(colorAccent)
+
+	// Column title
+	columnTitleStyle = lipgloss.NewStyle().
+		Bold(true).
+		Foreground(colorHeader)
+
+	columnTitleInactiveStyle = lipgloss.NewStyle().
+		Foreground(colorDim)
+
+	columnUnderlineStyle = lipgloss.NewStyle().
+		Foreground(colorSeparator)
+
+	// Separator between columns (vertical pipe)
+	columnSeparatorStyle = lipgloss.NewStyle().
+		Foreground(colorSeparator)
+
+	// Cursor bar for active column
+	cursorBarStyle = lipgloss.NewStyle().
+		Foreground(colorAccent).
+		Bold(true)
+
+	// Footer
+	footerSepStyle = lipgloss.NewStyle().
+		Foreground(colorSeparator)
+
 	footerStyle = lipgloss.NewStyle().
-			Foreground(colorGray).
-			Padding(0, 1)
+		Foreground(colorDim).
+		Padding(0, 2)
 
-	// Path style (for bottom of screen)
-	pathStyle = lipgloss.NewStyle().
-			Bold(true).
-			Foreground(colorBlue).
-			Padding(0, 1)
-
-	// Active column border
-	activeColumnStyle = lipgloss.NewStyle().
-				Border(lipgloss.RoundedBorder()).
-				BorderForeground(colorCyan).
-				Padding(0, 1)
-
-	// Inactive column border
-	inactiveColumnStyle = lipgloss.NewStyle().
-				Border(lipgloss.RoundedBorder()).
-				BorderForeground(colorGray).
-				Padding(0, 1)
-
-	// Section header style
+	// Section header (subtle label within columns)
 	sectionHeaderStyle = lipgloss.NewStyle().
-				Bold(true).
-				Underline(true).
-				Foreground(colorYellow)
+		Foreground(colorDim).
+		Bold(true)
 
-	// Selected item style
+	// Selected item
 	selectedItemStyle = lipgloss.NewStyle().
-				Bold(true).
-				Foreground(lipgloss.Color("15"))
+		Bold(true).
+		Foreground(lipgloss.Color("15"))
 
 	// Document indicator style
 	docIndicatorStyle = lipgloss.NewStyle().
-				Foreground(colorGreen)
+		Foreground(colorSuccess)
 
-	// Missing document style (documents with no data, only subcollections)
+	// Missing document
 	missingDocStyle = lipgloss.NewStyle().
-			Foreground(colorGray).
-			Faint(true)
+		Foreground(colorDim).
+		Faint(true)
 
 	// Collection indicator style
 	colIndicatorStyle = lipgloss.NewStyle().
-				Foreground(colorBlue)
+		Foreground(colorAccent)
 
-	// Error message style
+	// Error message
 	errorStyle = lipgloss.NewStyle().
-			Foreground(colorRed).
-			Bold(true)
+		Foreground(colorError).
+		Bold(true)
 
-	// Loading indicator style
+	// Loading indicator
 	loadingStyle = lipgloss.NewStyle().
-			Foreground(colorYellow).
-			Italic(true)
+		Foreground(colorWarning).
+		Italic(true)
 
 	// Status message style
 	statusStyle = lipgloss.NewStyle().
-			Foreground(colorGreen).
-			Italic(true).
-			Padding(0, 1)
+		Foreground(colorSuccess).
+		Italic(true).
+		Padding(0, 2)
 
-	// Tree View Data Type Styles
+	// Tree View Data Type Styles (muted/pastel)
 	treeKeyStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("205")) // Hot Pink for keys
+		Foreground(lipgloss.Color("139")) // Lavender
 
 	treeStringStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("113")) // Green for strings
+		Foreground(lipgloss.Color("108")) // Sage green
 
 	treeNumberStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("215")) // Orange/Gold for numbers
+		Foreground(lipgloss.Color("180")) // Warm sand
 
 	treeBoolStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("33")) // Blue for booleans
+		Foreground(lipgloss.Color("110")) // Soft blue
 
 	treeNullStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("240")). // Dark gray for null
-			Italic(true)
+		Foreground(lipgloss.Color("242")). // Dim gray
+		Italic(true)
 
 	treeTypeStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("245")). // Light gray for object/array type indicators
-			Italic(true)
+		Foreground(lipgloss.Color("245")). // Light gray
+		Italic(true)
 
-	// Input dialog style
+	// Dialogs (keep borders — they float over content)
+	infoDialogStyle = lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(colorAccent).
+		Padding(1, 3)
+
 	inputDialogStyle = lipgloss.NewStyle().
-				Border(lipgloss.RoundedBorder()).
-				BorderForeground(colorCyan).
-				Padding(1, 2)
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(colorAccent).
+		Padding(1, 2)
 
-	// Sort dialog styles
 	sortDialogStyle = lipgloss.NewStyle().
-			Border(lipgloss.RoundedBorder()).
-			BorderForeground(colorCyan).
-			Padding(1, 2).
-			Width(50)
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(colorAccent).
+		Padding(1, 2).
+		Width(50)
 
 	sortDirectionStyle = lipgloss.NewStyle().
-				Bold(true).
-				Foreground(colorYellow).
-				Align(lipgloss.Center)
+		Bold(true).
+		Foreground(colorWarning).
+		Align(lipgloss.Center)
 
 	sortHintStyle = lipgloss.NewStyle().
-			Foreground(colorGray).
-			Italic(true)
+		Foreground(colorDim).
+		Italic(true)
 
 	deleteDialogStyle = lipgloss.NewStyle().
-				Border(lipgloss.RoundedBorder()).
-				BorderForeground(colorRed).
-				Padding(1, 2).
-				Width(50)
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(colorError).
+		Padding(1, 2).
+		Width(50)
 
 	// Mode indicator styles
 	modeNormalStyle = lipgloss.NewStyle().
-			Bold(true).
-			Foreground(lipgloss.Color("0")).
-			Background(colorGreen).
-			Padding(0, 1)
+		Bold(true).
+		Foreground(lipgloss.Color("0")).
+		Background(colorSuccess).
+		Padding(0, 1)
 
 	modeVisualStyle = lipgloss.NewStyle().
-			Bold(true).
-			Foreground(lipgloss.Color("0")).
-			Background(colorYellow).
-			Padding(0, 1)
+		Bold(true).
+		Foreground(lipgloss.Color("0")).
+		Background(colorWarning).
+		Padding(0, 1)
 
 	modeCommandStyle = lipgloss.NewStyle().
-				Bold(true).
-				Foreground(lipgloss.Color("0")).
-				Background(colorBlue).
-				Padding(0, 1)
+		Bold(true).
+		Foreground(lipgloss.Color("0")).
+		Background(colorAccent).
+		Padding(0, 1)
 
-	// Status bar style
+	// Status bar
 	statusBarStyle = lipgloss.NewStyle().
-			Foreground(colorGray).
-			Padding(0, 1)
+		Foreground(colorDim).
+		Padding(0, 2)
 
-	// Visual mode selected item style
+	// Visual mode selected item
 	visualSelectedStyle = lipgloss.NewStyle().
-				Bold(true).
-				Foreground(lipgloss.Color("0")).
-				Background(colorYellow)
+		Bold(true).
+		Foreground(lipgloss.Color("0")).
+		Background(colorWarning)
 
-	// Preview pane style
-	previewStyle = lipgloss.NewStyle().
-			Border(lipgloss.RoundedBorder()).
-			BorderForeground(colorGreen).
-			Padding(0, 1)
+	// Preview pane (borderless, matches other columns)
+	previewStyle = lipgloss.NewStyle()
+
+	// Path style (used by header breadcrumb)
+	pathStyle = headerPathStyle
+
+	// Legacy alias — headerStyle is used in overlay dialog
+	headerStyle = headerProjectStyle
 )

--- a/pkg/cmd/browse/update.go
+++ b/pkg/cmd/browse/update.go
@@ -842,7 +842,7 @@ func (m Model) applySortAndClose() (tea.Model, tea.Cmd) {
 // handleCommandMode processes input in command mode
 func (m Model) handleCommandMode(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
-	case "esc":
+	case "esc", "ctrl+c":
 		m.mode = ModeNormal
 		m.commandInput.Blur()
 		m.commandInput.Reset()

--- a/pkg/cmd/browse/update.go
+++ b/pkg/cmd/browse/update.go
@@ -421,8 +421,12 @@ func (m Model) handleKeyPress(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 	switch msg.String() {
 	// Quit
-	case "q", "esc", "ctrl+c":
+	case "q", "ctrl+c":
 		return m, tea.Quit
+	case "esc":
+		m.statusMsg = "Press q to quit"
+		m.statusMsgTime = time.Now()
+		return m, clearStatusAfterDelay()
 
 	// Vertical navigation (within column)
 	case "j", "down":

--- a/pkg/cmd/browse/update.go
+++ b/pkg/cmd/browse/update.go
@@ -758,12 +758,14 @@ func (m Model) handleOverlay(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 	case OverlayInfo:
 		switch msg.String() {
-		case "esc", "q", "enter":
+		case "esc", "q":
 			m.overlay = OverlayNone
 			m.infoContent = ""
 			return m, nil
 		}
-		return m, nil
+		var cmd tea.Cmd
+		m.infoViewport, cmd = m.infoViewport.Update(msg)
+		return m, cmd
 
 	case OverlayFilter:
 		switch msg.String() {
@@ -883,6 +885,10 @@ func (m Model) handleCommandMode(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			if strings.Contains(statusText, "\n") {
 				m.overlay = OverlayInfo
 				m.infoContent = statusText
+				vpWidth := min(m.width-8, 72)
+				vpHeight := min(m.height-8, strings.Count(statusText, "\n")+1)
+				m.infoViewport = viewport.New(vpWidth, vpHeight)
+				m.infoViewport.SetContent(statusText)
 			} else {
 				m.statusMsg = statusText
 				m.statusMsgTime = time.Now()

--- a/pkg/cmd/browse/update.go
+++ b/pkg/cmd/browse/update.go
@@ -20,6 +20,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.KeyMsg:
 		logDebug("KeyMsg received: %s (mode=%s, overlay=%d)", msg.String(), m.mode, m.overlay)
 
+		// Dismiss notification on any keypress
+		if m.statusMsg != "" {
+			m.statusMsg = ""
+		}
+
 		// Handle overlays first (dialogs on top of any mode)
 		if m.overlay != OverlayNone {
 			return m.handleOverlay(msg)

--- a/pkg/cmd/browse/update.go
+++ b/pkg/cmd/browse/update.go
@@ -88,9 +88,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Update viewport sizes for document columns
 		for i := range m.columns {
 			if m.columns[i].isDoc && m.columns[i].docContent != "" {
-				colWidth := calculateColumnWidth(m.width, len(m.columns))
-				colHeight := m.height - 7 // Account for header and footer
-				vpWidth := colWidth - 4
+				colWidth := calculateColumnWidth(m.width-4, len(m.columns))
+				colHeight := m.itemViewHeight()
+				vpWidth := colWidth - 2
 				vpHeight := colHeight - 10
 				// Ensure minimum viewport dimensions (at least 20x5)
 				if vpWidth >= 20 && vpHeight >= 5 {
@@ -145,10 +145,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// Initialize viewport if this is a document column
 			// Only create viewport if we have valid dimensions
 			if m.columns[msg.columnIndex].isDoc && msg.docContent != "" && m.width > 0 && m.height > 0 {
-				colWidth := calculateColumnWidth(m.width, len(m.columns))
-				colHeight := m.height - 7
-				// Ensure minimum viewport dimensions (at least 20x5)
-				vpWidth := colWidth - 4
+				colWidth := calculateColumnWidth(m.width-4, len(m.columns))
+				colHeight := m.itemViewHeight()
+				vpWidth := colWidth - 2
 				vpHeight := colHeight - 10
 				if vpWidth >= 20 && vpHeight >= 5 {
 					m.columns[msg.columnIndex].viewport = viewport.New(vpWidth, vpHeight)
@@ -748,6 +747,15 @@ func (m Model) handleOverlay(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 
+	case OverlayInfo:
+		switch msg.String() {
+		case "esc", "q", "enter":
+			m.overlay = OverlayNone
+			m.infoContent = ""
+			return m, nil
+		}
+		return m, nil
+
 	case OverlayFilter:
 		switch msg.String() {
 		case "esc":
@@ -863,8 +871,13 @@ func (m Model) handleCommandMode(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 
 		if statusText != "" {
-			m.statusMsg = statusText
-			m.statusMsgTime = time.Now()
+			if strings.Contains(statusText, "\n") {
+				m.overlay = OverlayInfo
+				m.infoContent = statusText
+			} else {
+				m.statusMsg = statusText
+				m.statusMsgTime = time.Now()
+			}
 		}
 
 		// Check if the handler set a pending editor launch

--- a/pkg/cmd/browse/update.go
+++ b/pkg/cmd/browse/update.go
@@ -884,6 +884,10 @@ func (m Model) handleCommandMode(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			}
 		}
 
+		if m.pendingQuit {
+			return m, tea.Quit
+		}
+
 		// Check if the handler set a pending editor launch
 		if m.pendingEditor != nil {
 			cmd := m.pendingEditor

--- a/pkg/cmd/browse/view.go
+++ b/pkg/cmd/browse/view.go
@@ -7,12 +7,28 @@ import (
 	"github.com/charmbracelet/lipgloss"
 )
 
+func extractColumnTitle(col Column) string {
+	if col.path == "" {
+		return "Collections"
+	}
+	parts := strings.Split(col.path, "/")
+	return parts[len(parts)-1]
+}
+
+func verticalSeparator(height int) string {
+	styled := columnSeparatorStyle.Render(" │ ")
+	lines := make([]string, height)
+	for i := range lines {
+		lines[i] = styled
+	}
+	return strings.Join(lines, "\n")
+}
+
 // View renders the entire TUI
 func (m Model) View() string {
 	defer func() {
 		if r := recover(); r != nil {
 			logDebug("PANIC in View: %v", r)
-			// Don't re-panic, return error message instead
 		}
 	}()
 
@@ -22,8 +38,9 @@ func (m Model) View() string {
 		return "Initializing..."
 	}
 
-	// Construct path string from columns
-	var pathSegments []string
+	// Breadcrumb header: project › segment1 › segment2
+	var breadcrumb strings.Builder
+	breadcrumb.WriteString(headerProjectStyle.Render(m.projectID))
 	for i, col := range m.columns {
 		if i > m.activeColumn {
 			break
@@ -35,13 +52,12 @@ func (m Model) View() string {
 		if len(parts) > 0 {
 			segment := parts[len(parts)-1]
 			if segment != "" {
-				pathSegments = append(pathSegments, segment)
+				breadcrumb.WriteString(headerSepStyle.Render("  ›  "))
+				breadcrumb.WriteString(headerPathStyle.Render(segment))
 			}
 		}
 	}
-	fullPath := "/" + strings.Join(pathSegments, "/")
 
-	// Header: project ID | path | mode indicator
 	modeIndicator := modeNormalStyle.Render("[" + m.mode.String() + "]")
 	switch m.mode {
 	case ModeVisual:
@@ -51,13 +67,47 @@ func (m Model) View() string {
 		modeIndicator = modeCommandStyle.Render("[COMMAND]")
 	}
 
-	headerLeft := headerStyle.Render(m.projectID)
-	headerPath := pathStyle.Render(fullPath)
+	headerLeft := breadcrumb.String()
 	headerRight := modeIndicator
-	headerGap := strings.Repeat(" ", max(m.width-lipgloss.Width(headerLeft)-lipgloss.Width(headerPath)-lipgloss.Width(headerRight)-2, 1))
-	header := headerLeft + " " + headerPath + headerGap + headerRight
+	headerGap := strings.Repeat(" ", max(m.width-lipgloss.Width(headerLeft)-lipgloss.Width(headerRight)-4, 1))
+	header := "  " + headerLeft + headerGap + headerRight + "  "
 
-	// Footer: context-sensitive hints, command prompt, or filter input
+	// Columns
+	columnsView := m.renderColumns()
+	logDebug("View: columnsView length=%d", len(columnsView))
+
+	// Separator line + combined status/footer
+	separatorLine := "  " + footerSepStyle.Render(strings.Repeat("─", max(m.width-4, 0)))
+
+	// Build left side: status info
+	var statusParts []string
+	if m.activeColumn < len(m.columns) {
+		col := m.columns[m.activeColumn]
+		if !col.isDoc && col.docCount > 0 {
+			statusParts = append(statusParts, fmt.Sprintf("%d docs", col.docCount))
+		}
+		if col.activeQuery != nil {
+			statusParts = append(statusParts, "Query: "+col.activeQuery.String())
+		}
+	}
+	if m.filterActive && m.filterPattern != "" {
+		statusParts = append(statusParts, "Filter: "+m.filterPattern)
+	}
+	if m.previewEnabled {
+		statusParts = append(statusParts, "Preview: ON")
+	}
+
+	// Error/loading inline
+	if m.err != nil {
+		statusParts = append(statusParts, errorStyle.Render(fmt.Sprintf("Error: %v", m.err)))
+	}
+	if m.loading {
+		statusParts = append(statusParts, loadingStyle.Render("Loading..."))
+	}
+
+	statusLeft := strings.Join(statusParts, "  │  ")
+
+	// Footer: context-sensitive hints or command input
 	var footer string
 	if m.mode == ModeCommand {
 		commandLine := m.commandInput.View()
@@ -72,42 +122,43 @@ func (m Model) View() string {
 	} else if m.overlay == OverlayFilter {
 		footer = m.filterInput.View()
 	} else {
-		footer = footerStyle.Render(m.getFooterHints())
+		hintsRight := m.getFooterHints()
+		gap := strings.Repeat(" ", max(m.width-lipgloss.Width(statusLeft)-lipgloss.Width(hintsRight)-4, 1))
+		footer = footerStyle.Render(statusLeft + gap + hintsRight)
 	}
-
-	// Status bar (placeholder between columns and footer)
-	statusBar := m.renderStatusBar()
-
-	// Error message
-	errorView := ""
-	if m.err != nil {
-		errorView = errorStyle.Render(fmt.Sprintf("Error: %v", m.err))
-	}
-
-	// Loading indicator
-	loadingMsg := ""
-	if m.loading {
-		loadingMsg = loadingStyle.Render("Loading...")
-	}
-
-	// Render columns
-	columnsView := m.renderColumns()
-	logDebug("View: columnsView length=%d", len(columnsView))
 
 	// Combine all parts
 	logDebug("View: about to JoinVertical")
 	content := lipgloss.JoinVertical(
 		lipgloss.Left,
 		header,
+		"",
 		columnsView,
-		statusBar,
-		errorView,
-		loadingMsg,
+		separatorLine,
 		footer,
 	)
+	// Ensure content fills terminal height so overlays center correctly
+	content = lipgloss.Place(m.width, m.height, lipgloss.Left, lipgloss.Top, content)
 	logDebug("View: JoinVertical successful, contentLen=%d", len(content))
 
-	// Overlay dialogs
+	// Overlay dialogs — all centered over the main layout
+	if m.overlay == OverlayInfo {
+		dialogContent := lipgloss.JoinVertical(
+			lipgloss.Left,
+			m.infoContent,
+			"",
+			footerStyle.Render("Esc/q/Enter: close"),
+		)
+		dialog := infoDialogStyle.Render(dialogContent)
+		return lipgloss.Place(
+			m.width,
+			m.height,
+			lipgloss.Center,
+			lipgloss.Center,
+			dialog,
+		)
+	}
+
 	if m.overlay == OverlayPathInput {
 		dialogContent := lipgloss.JoinVertical(
 			lipgloss.Center,
@@ -169,38 +220,30 @@ func (m Model) View() string {
 		)
 	}
 
-	// Overlay status notification if present (floating window)
+	// Floating status notification
 	if m.statusMsg != "" {
-		// Create notification box with border
 		notificationStyle := lipgloss.NewStyle().
 			Border(lipgloss.RoundedBorder()).
 			BorderForeground(colorGreen).
-			Background(lipgloss.Color("235")). // Dark background
+			Background(lipgloss.Color("235")).
 			Foreground(colorGreen).
 			Padding(0, 1).
 			Bold(true)
 
 		notification := notificationStyle.Render(m.statusMsg)
 
-		// Split content into lines
 		lines := strings.Split(content, "\n")
 
-		// Calculate position near bottom but above footer
-		// Footer is typically the last line, so place notification a few lines above
 		notificationLine := len(lines) - 3
 		if notificationLine < 2 {
-			notificationLine = 2 // Minimum position from top
+			notificationLine = 2
 		}
-
-		// Make sure we don't go beyond the content
 		if notificationLine >= len(lines) {
 			notificationLine = len(lines) - 1
 		}
 
-		// Position notification at bottom right
 		notificationLines := strings.Split(notification, "\n")
 
-		// Overlay each line of the notification at the right edge
 		for i, notifLine := range notificationLines {
 			linePos := notificationLine + i
 			if linePos < len(lines) {
@@ -208,31 +251,26 @@ func (m Model) View() string {
 				existingLine := lines[linePos]
 				existingWidth := lipgloss.Width(existingLine)
 
-				// Calculate padding to align to the right
-				leftPad := existingWidth - notifWidth - 2 // -2 for a small margin from right edge
+				leftPad := existingWidth - notifWidth - 2
 				if leftPad < 0 {
 					leftPad = 0
 				}
 
-				// Align to right by adding left padding
 				if leftPad+notifWidth <= existingWidth {
-					// Right-align with padding
 					lines[linePos] = strings.Repeat(" ", leftPad) + notifLine
 				} else {
-					// Notification is wider than existing line, just place it
 					lines[linePos] = notifLine
 				}
 			}
 		}
 
-		// Rejoin the content
 		content = strings.Join(lines, "\n")
 	}
 
 	return content
 }
 
-// renderColumns renders all visible columns side by side
+// renderColumns renders all visible columns side by side with separators
 func (m Model) renderColumns() string {
 	defer func() {
 		if r := recover(); r != nil {
@@ -246,261 +284,154 @@ func (m Model) renderColumns() string {
 
 	visibleCols := getVisibleColumns(m.columns, m.activeColumn)
 
-	// Calculate column width, reserving space for preview if enabled
-	previewWidth := 0
-	totalWidth := m.width
-	if m.previewEnabled && len(m.previewNodes) > 0 {
-		previewWidth = totalWidth / 3
-		totalWidth -= previewWidth
+	// Height for columns area: total height minus header(1), blank(1), separator(1), footer(1), margin(1)
+	height := m.height - 5
+	if height < 6 {
+		height = 6
 	}
-	colWidth := calculateColumnWidth(totalWidth, len(visibleCols))
+
+	// Calculate column width
+	sepWidth := 3 // " │ "
+	margin := 4  // 2 padding on each side
+
+	previewWidth := 0
+	availWidth := m.width - margin
+	if m.previewEnabled && len(m.previewNodes) > 0 {
+		previewWidth = (m.width - margin) / 3
+		availWidth -= previewWidth + sepWidth
+	}
+
+	colWidth := calculateColumnWidth(availWidth, len(visibleCols))
 	logDebug("renderColumns: visibleCols=%d, colWidth=%d, previewWidth=%d", len(visibleCols), colWidth, previewWidth)
 
-	var renderedCols []string
+	var parts []string
 	for i, col := range visibleCols {
 		isActive := (i == m.activeColumn) || (len(m.columns) > 4 && i == 3)
 
-		rendered := m.renderColumn(col, colWidth, isActive)
+		if i > 0 {
+			parts = append(parts, verticalSeparator(height))
+		}
+
+		rendered := m.renderColumn(col, colWidth, height, isActive)
 		logDebug("renderColumns: column %d rendered, length=%d", i, len(rendered))
-		renderedCols = append(renderedCols, rendered)
+		parts = append(parts, rendered)
 	}
 
 	// Add preview pane if enabled
 	if m.previewEnabled && previewWidth > 0 && len(m.previewNodes) > 0 {
-		previewCol := m.renderPreviewPane(previewWidth)
-		renderedCols = append(renderedCols, previewCol)
+		parts = append(parts, verticalSeparator(height))
+		previewCol := m.renderPreviewPane(previewWidth, height)
+		parts = append(parts, previewCol)
 	}
 
-	logDebug("renderColumns: about to JoinHorizontal with %d columns", len(renderedCols))
-	result := lipgloss.JoinHorizontal(lipgloss.Top, renderedCols...)
+	logDebug("renderColumns: about to JoinHorizontal with %d parts", len(parts))
+	result := lipgloss.JoinHorizontal(lipgloss.Top, parts...)
 	logDebug("renderColumns: JoinHorizontal successful, resultLen=%d", len(result))
-	return result
+
+	// Add horizontal margin
+	return lipgloss.NewStyle().Padding(0, 2).Render(result)
 }
 
-// Helper to render tree nodes recursively
-func (m Model) renderTreeNodes(
-	nodes []ListItem,
-	level int,
-	cursor int,
-	itemIndex *int,
-	content *strings.Builder,
-	wrapper lipgloss.Style,
-	innerWidth int,
-) int {
-	linesUsed := 0
-
-	for _, node := range nodes {
-		prefix := strings.Repeat("  ", level)
-
-		cursorMarker := "  "
-		if *itemIndex == cursor {
-			cursorMarker = "> "
-		}
-
-		// Icon for expandable items
-		icon := " "
-		if node.dataType == "object" || node.dataType == "array" {
-			if node.expanded {
-				icon = "▼"
-			} else {
-				icon = "▶"
-			}
-		}
-
-		// Style the key
-		keyStr := treeKeyStyle.Render(node.key)
-
-		// Style the value
-		valStr := ""
-		switch node.dataType {
-		case "string":
-			valStr = treeStringStyle.Render(fmt.Sprintf("%q", node.valueStr))
-		case "number":
-			valStr = treeNumberStyle.Render(node.valueStr)
-		case "bool":
-			valStr = treeBoolStyle.Render(node.valueStr)
-		case "null":
-			valStr = treeNullStyle.Render("null")
-		case "object", "array":
-			// Show type hint (e.g. "Object {2}" or "Array [5]")
-			// If we had count, we could show it, for now just show type
-			if node.dataType == "array" {
-				valStr = treeTypeStyle.Render(fmt.Sprintf("[%d]", len(node.children)))
-			} else {
-				valStr = treeTypeStyle.Render("{}")
-			}
-		default:
-			valStr = node.valueStr
-		}
-
-		// Build line: marker + indent + icon + key + ": " + value
-		// Note: we removed the dot point for leaf nodes as requested
-		lineStr := fmt.Sprintf("%s%s%s %s: %s", cursorMarker, prefix, icon, keyStr, valStr)
-
-		// Style the line selection (inverse background or similar might be better,
-		// but let's stick to simple bold/highlight for now, preserving color)
-		if *itemIndex == cursor {
-			// When selected, we might want to keep the colors but add an indicator
-			// or change background. For now, let's just make the cursor indicator bold/visible
-			// and keep the syntax highlighting.
-			// Re-building line with selected indicator style only on the marker/prefix if possible
-			// But since we are rendering the whole string, let's just use a selection style
-			// that doesn't strip color if possible, or just bold it.
-
-			// Simple approach: Use a different background for the whole line?
-			// Or just rely on the ">" marker which is already there.
-			// Let's wrap the whole line in a style that might add a background or bold
-			// without overriding foreground colors if lipgloss supports it.
-			// Lipgloss Foreground() overrides existing colors.
-			// So let's just use the marker ">" which is already distinct.
-
-			// However, the original code did: lineStr = selectedItemStyle.Render(lineStr)
-			// which forces white color. Let's just bold it and maybe add a background.
-			lineStr = lipgloss.NewStyle().Bold(true).Render(lineStr)
-		}
-
-		// Wrap and write
-		wrappedLine := wrapper.Render(lineStr)
-		content.WriteString(wrappedLine)
-		content.WriteString("\n")
-		linesUsed += strings.Count(wrappedLine, "\n") + 1
-
-		*itemIndex++
-
-		// Render children if expanded
-		if node.expanded && len(node.children) > 0 {
-			linesUsed += m.renderTreeNodes(
-				node.children,
-				level+1,
-				cursor,
-				itemIndex,
-				content,
-				wrapper,
-				innerWidth,
-			)
-		}
-	}
-
-	return linesUsed
-}
-
-// renderColumn renders a single column
-func (m Model) renderColumn(col Column, width int, isActive bool) string {
+// renderColumn renders a single column (borderless)
+func (m Model) renderColumn(col Column, width, height int, isActive bool) string {
 	defer func() {
 		if r := recover(); r != nil {
 			logPanic("renderColumn", r)
-			panic(r) // re-panic after logging
+			panic(r)
 		}
 	}()
 
-	// Calculate available height
-	// m.height includes:
-	// - header (1)
-	// - status bar (1)
-	// - footer (1)
-	// - error/loading (1)
-	// - some margin (1)
-	// Total overhead = 5
-	// We also need to account for the border (top + bottom = 2)
-	height := m.height - 5 - 2
-	if height < 1 {
-		height = 10 // Minimum height
+	// Column header: title + underline
+	title := extractColumnTitle(col)
+	var headerBuf strings.Builder
+	if isActive {
+		headerBuf.WriteString(columnTitleStyle.Render(title))
+	} else {
+		headerBuf.WriteString(columnTitleInactiveStyle.Render(title))
+	}
+	headerBuf.WriteString("\n")
+	underlineLen := min(lipgloss.Width(title), width)
+	headerBuf.WriteString(columnUnderlineStyle.Render(strings.Repeat("─", underlineLen)))
+	headerBuf.WriteString("\n")
+
+	headerLines := 2
+	itemsHeight := height - headerLines
+	if itemsHeight < 1 {
+		itemsHeight = 1
 	}
 
-	// Calculate inner width for wrapping
-	// Width - Border(2) - Padding(2) = Width - 4
-	innerWidth := max(width-4, 1)
+	innerWidth := max(width-2, 1) // 1 char padding on each side for content
 
 	// Apply filter to sections for active column
 	sections := m.getEffectiveSections(col)
 
 	logDebug(
 		"renderColumn: width=%d, innerWidth=%d, height=%d, isActive=%v, sections=%d",
-		width,
-		innerWidth,
-		height,
-		isActive,
-		len(sections),
+		width, innerWidth, height, isActive, len(sections),
 	)
 
 	var content strings.Builder
 	itemIndex := 0
 	linesUsed := 0
 
-	// Helper style for wrapping document content
 	wrapper := lipgloss.NewStyle().Width(innerWidth)
 
-	// Render sections
 	for _, section := range sections {
 		if section.hidden {
 			continue
 		}
 
-		// Section header
-		// Truncate title if needed to ensure 1 line
-		title := section.title
-		if len(title) > innerWidth {
-			title = title[:innerWidth-3] + "..."
+		// Section header (subtle label)
+		if section.title != "Documents" || col.isDoc {
+			sTitle := section.title
+			if len(sTitle) > innerWidth {
+				sTitle = sTitle[:innerWidth-3] + "..."
+			}
+			content.WriteString(sectionHeaderStyle.Render(sTitle))
+			content.WriteString("\n")
+			linesUsed++
 		}
-		headerStr := sectionHeaderStyle.Render(title)
-		content.WriteString(headerStr)
-		content.WriteString("\n")
-		linesUsed++
 
-		// Section items
 		if section.title == "Data" {
-			// Special rendering for Data section (tree view)
-			// Pass current itemIndex pointer to track global index in column
 			idx := itemIndex
 			used := m.renderTreeNodes(
-				section.items,
-				0,
-				col.cursor,
-				&idx,
-				&content,
-				wrapper,
-				innerWidth,
+				section.items, 0, col.cursor, &idx, &content, wrapper, innerWidth, isActive,
 			)
 			linesUsed += used
 			itemIndex = idx
 		} else {
-			// Standard list rendering
 			for _, item := range section.items {
 				prefix := "  "
-				if itemIndex == col.cursor {
-					prefix = "> "
+				if itemIndex == col.cursor && isActive {
+					prefix = cursorBarStyle.Render("▌") + " "
 				}
 
-				// Visual selection marker
-				selMark := " "
+				selMark := ""
 				if m.mode == ModeVisual && m.selection.IsSelected(itemIndex) {
-					selMark = "●"
+					selMark = "● "
 				}
 
-				extraChars := 4
-				availWidth := max(innerWidth-extraChars, 5)
-
+				availWidth := max(innerWidth-lipgloss.Width(prefix)-lipgloss.Width(selMark)-1, 5)
 				displayID := item.id
 				if len(displayID) > availWidth {
 					displayID = displayID[:availWidth-3] + "..."
 				}
 
-				line := fmt.Sprintf("%s%s%s", prefix, selMark, displayID)
+				// Use · prefix for items in document sections
+				dot := ""
+				if col.isDoc && section.title != "Data" {
+					dot = "· "
+				}
+
+				line := fmt.Sprintf("%s%s%s%s", prefix, selMark, dot, displayID)
 				if item.isMissing {
-					line = fmt.Sprintf("%s%s%s", prefix, selMark, missingDocStyle.Render(displayID+" (no data)"))
+					line = fmt.Sprintf("%s%s%s%s", prefix, selMark, dot, missingDocStyle.Render(displayID+" (no data)"))
 				}
 
 				if m.mode == ModeVisual && m.selection.IsSelected(itemIndex) {
 					line = visualSelectedStyle.Render(line)
-				} else if itemIndex == col.cursor {
-					line = selectedItemStyle.Render(
-						fmt.Sprintf("%s%s%s", prefix, selMark, displayID),
-					)
-					if item.isMissing {
-						line = selectedItemStyle.Render(
-							fmt.Sprintf("%s%s%s (no data)", prefix, selMark, displayID),
-						)
-					}
+				} else if itemIndex == col.cursor && isActive {
+					line = selectedItemStyle.Render(line)
 				}
 
 				content.WriteString(line)
@@ -513,8 +444,7 @@ func (m Model) renderColumn(col Column, width int, isActive bool) string {
 		linesUsed++
 	}
 
-	// If this is a document column, render document content (RAW JSON fallback/debug)
-	// We only show this if we DON'T have a Data section (which we should always have now)
+	// Raw JSON fallback for document columns without Data section
 	hasDataSection := false
 	for _, s := range sections {
 		if s.title == "Data" {
@@ -524,16 +454,9 @@ func (m Model) renderColumn(col Column, width int, isActive bool) string {
 	}
 
 	if col.isDoc && col.docContent != "" && !hasDataSection {
-		// Calculate remaining space for document content
-		remainingLines := height - linesUsed - 2 // Leave 2 lines margin
-		logDebug(
-			"DOCUMENT CONTENT: height=%d, linesUsed=%d, remainingLines=%d",
-			height,
-			linesUsed,
-			remainingLines,
-		)
+		remainingLines := itemsHeight - linesUsed - 2
+		logDebug("DOCUMENT CONTENT: height=%d, linesUsed=%d, remainingLines=%d", height, linesUsed, remainingLines)
 
-		// Always render document content if we are in a doc column
 		if remainingLines > 2 {
 			headerStr := sectionHeaderStyle.Render("Document Content")
 			wrappedHeader := wrapper.Render(headerStr)
@@ -542,152 +465,157 @@ func (m Model) renderColumn(col Column, width int, isActive bool) string {
 			linesUsed += strings.Count(wrappedHeader, "\n") + 1
 			remainingLines -= strings.Count(wrappedHeader, "\n") + 1
 
-			// Wrap the document content to the inner width
 			wrappedDoc := wrapper.Render(col.docContent)
 			docLines := strings.Split(wrappedDoc, "\n")
-			logDebug(
-				"DOCUMENT CONTENT: original docLines=%d, remainingLines=%d",
-				len(docLines),
-				remainingLines,
-			)
+			logDebug("DOCUMENT CONTENT: original docLines=%d, remainingLines=%d", len(docLines), remainingLines)
 
-			// We don't truncate anymore because scrolling will handle visibility
 			content.WriteString(strings.Join(docLines, "\n"))
 			linesUsed += len(docLines)
 			logDebug("DOCUMENT CONTENT: after adding doc, linesUsed=%d", linesUsed)
-		} else {
-			logDebug("DOCUMENT CONTENT: SKIPPED - not enough space (remainingLines=%d)", remainingLines)
 		}
 	}
 
-	// Apply column style
+	// Apply scrolling
 	columnContent := content.String()
 	if len(columnContent) == 0 {
 		columnContent = "No items"
 	}
 
-	logDebug(
-		"Before scrolling: linesUsed=%d, contentLines=%d, height=%d",
-		linesUsed,
-		strings.Count(columnContent, "\n")+1,
-		height,
-	)
-
-	// Apply scrolling - show only the visible portion
 	lines := strings.Split(columnContent, "\n")
 	totalLines := len(lines)
 
-	// Calculate bounds
-	maxScroll := max(totalLines-height, 0)
-
-	// Use scroll offset (bounds are enforced in scroll functions)
+	maxScroll := max(totalLines-itemsHeight, 0)
 	scrollOffset := min(max(col.scrollOffset, 0), maxScroll)
 
-	// Extract visible lines based on scroll position
 	startLine := scrollOffset
-	endLine := min(scrollOffset+height, totalLines)
-
+	endLine := min(scrollOffset+itemsHeight, totalLines)
 	visibleLines := lines[startLine:endLine]
 
-	// Final safety check - ensure we never exceed height
-	if len(visibleLines) > height {
-		visibleLines = visibleLines[:height]
+	if len(visibleLines) > itemsHeight {
+		visibleLines = visibleLines[:itemsHeight]
 	}
 
-	// Add scroll indicators if needed
-	if scrollOffset > 0 {
-		// Can scroll up - add indicator at top
-		if len(visibleLines) > 0 {
-			visibleLines[0] = "▲ " + visibleLines[0]
-		}
+	if scrollOffset > 0 && len(visibleLines) > 0 {
+		visibleLines[0] = "▲ " + visibleLines[0]
 	}
-	if scrollOffset < maxScroll {
-		// Can scroll down - add indicator at bottom
-		if len(visibleLines) > 0 {
-			visibleLines[len(visibleLines)-1] = "▼ " + visibleLines[len(visibleLines)-1]
-		}
+	if scrollOffset < maxScroll && len(visibleLines) > 0 {
+		visibleLines[len(visibleLines)-1] = "▼ " + visibleLines[len(visibleLines)-1]
 	}
 
-	columnContent = strings.Join(visibleLines, "\n")
+	scrolledContent := strings.Join(visibleLines, "\n")
 
-	// Apply border style
-	finalLineCount := strings.Count(columnContent, "\n") + 1
-	logDebug(
-		"About to render with lipgloss: width=%d, height=%d, visibleLines=%d, finalLineCount=%d",
-		width,
-		height,
-		len(visibleLines),
-		finalLineCount,
-	)
+	// Combine header + scrolled content
+	finalContent := headerBuf.String() + scrolledContent
 
-	var result string
-	defer func() {
-		if r := recover(); r != nil {
-			logDebug("PANIC in lipgloss render: %v", r)
-			logDebug(
-				"width=%d, height=%d, isActive=%v, contentLen=%d",
-				width,
-				height,
-				isActive,
-				len(columnContent),
-			)
-			// Return a simple string instead of panicking
-			result = fmt.Sprintf("Error rendering column (w=%d,h=%d)", width, height)
-		}
-	}()
-
-	// Always set explicit height on the style to ensure full height columns
-	if isActive {
-		result = activeColumnStyle.Width(width).Height(height).Render(columnContent)
-	} else {
-		result = inactiveColumnStyle.Width(width).Height(height).Render(columnContent)
-	}
-
-	resultLineCount := strings.Count(result, "\n") + 1
-	logDebug(
-		"Lipgloss render successful - input lines: %d, output lines: %d, expected max: %d",
-		finalLineCount,
-		resultLineCount,
-		height,
-	)
-
-	if resultLineCount > height+4 {
-		logDebug("WARNING: Output exceeds expected height by %d lines!", resultLineCount-(height+4))
-	}
-
-	return result
+	// Render with fixed dimensions (no border)
+	return lipgloss.NewStyle().Width(width).Height(height).Render(finalContent)
 }
 
-func (m Model) renderPreviewPane(width int) string {
-	height := m.height - 5 - 2
-	if height < 1 {
-		height = 10
+// renderTreeNodes renders tree nodes recursively
+func (m Model) renderTreeNodes(
+	nodes []ListItem,
+	level int,
+	cursor int,
+	itemIndex *int,
+	content *strings.Builder,
+	wrapper lipgloss.Style,
+	innerWidth int,
+	isActive bool,
+) int {
+	linesUsed := 0
+
+	for _, node := range nodes {
+		prefix := strings.Repeat("  ", level)
+
+		cursorMarker := "  "
+		if *itemIndex == cursor && isActive {
+			cursorMarker = cursorBarStyle.Render("▌") + " "
+		}
+
+		icon := " "
+		if node.dataType == "object" || node.dataType == "array" {
+			if node.expanded {
+				icon = "▼"
+			} else {
+				icon = "▶"
+			}
+		}
+
+		keyStr := treeKeyStyle.Render(node.key)
+
+		valStr := ""
+		switch node.dataType {
+		case "string":
+			valStr = treeStringStyle.Render(fmt.Sprintf("%q", node.valueStr))
+		case "number":
+			valStr = treeNumberStyle.Render(node.valueStr)
+		case "bool":
+			valStr = treeBoolStyle.Render(node.valueStr)
+		case "null":
+			valStr = treeNullStyle.Render("null")
+		case "object", "array":
+			if node.dataType == "array" {
+				valStr = treeTypeStyle.Render(fmt.Sprintf("[%d]", len(node.children)))
+			} else {
+				valStr = treeTypeStyle.Render("{}")
+			}
+		default:
+			valStr = node.valueStr
+		}
+
+		lineStr := fmt.Sprintf("%s%s%s %s: %s", cursorMarker, prefix, icon, keyStr, valStr)
+
+		if *itemIndex == cursor && isActive {
+			lineStr = lipgloss.NewStyle().Bold(true).Render(lineStr)
+		}
+
+		wrappedLine := wrapper.Render(lineStr)
+		content.WriteString(wrappedLine)
+		content.WriteString("\n")
+		linesUsed += strings.Count(wrappedLine, "\n") + 1
+
+		*itemIndex++
+
+		if node.expanded && len(node.children) > 0 {
+			linesUsed += m.renderTreeNodes(
+				node.children, level+1, cursor, itemIndex, content, wrapper, innerWidth, isActive,
+			)
+		}
 	}
 
-	innerWidth := max(width-4, 1)
-	var content strings.Builder
+	return linesUsed
+}
 
-	// Title
+func (m Model) renderPreviewPane(width, height int) string {
+	innerWidth := max(width-2, 1)
+	var headerBuf strings.Builder
+
 	parts := strings.Split(m.previewPath, "/")
 	title := m.previewPath
 	if len(parts) > 0 {
 		title = parts[len(parts)-1]
 	}
-	content.WriteString(sectionHeaderStyle.Render("Preview: " + title))
-	content.WriteString("\n")
 
+	headerBuf.WriteString(columnTitleStyle.Render("Preview: " + title))
+	headerBuf.WriteString("\n")
+	underlineLen := min(lipgloss.Width("Preview: "+title), width)
+	headerBuf.WriteString(columnUnderlineStyle.Render(strings.Repeat("─", underlineLen)))
+	headerBuf.WriteString("\n")
+
+	var content strings.Builder
 	wrapper := lipgloss.NewStyle().Width(innerWidth)
 	itemIndex := 0
-	m.renderTreeNodes(m.previewNodes, 0, -1, &itemIndex, &content, wrapper, innerWidth)
+	m.renderTreeNodes(m.previewNodes, 0, -1, &itemIndex, &content, wrapper, innerWidth, false)
 
+	itemsHeight := height - 2
 	columnContent := content.String()
 	lines := strings.Split(columnContent, "\n")
-	if len(lines) > height {
-		lines = lines[:height]
+	if len(lines) > itemsHeight {
+		lines = lines[:itemsHeight]
 	}
-	columnContent = strings.Join(lines, "\n")
 
-	return previewStyle.Width(width).Height(height).Render(columnContent)
+	finalContent := headerBuf.String() + strings.Join(lines, "\n")
+	return lipgloss.NewStyle().Width(width).Height(height).Render(finalContent)
 }
 
 // getFooterHints returns context-sensitive keybinding hints
@@ -711,38 +639,11 @@ func (m Model) getFooterHints() string {
 	case ModeCommand:
 		return "Esc: Normal mode"
 	default:
-		return "j/k: Up/Down  h/l: Back/Forward  g/G: Top/Bottom  /: Filter  s: Sort  e: Edit  d: Delete  yy: Copy  :: Command  q: Quit"
+		return "j/k ↕  h/l ↔  g/G Top/Bottom  / Filter  s Sort  e Edit  d Del  yy Copy  : Cmd  q Quit"
 	}
 }
 
-// renderStatusBar renders the status bar area between columns and footer
+// renderStatusBar is kept for compatibility but status is now merged into footer
 func (m Model) renderStatusBar() string {
-	var parts []string
-
-	// Show pagination info and active query for active collection column
-	if m.activeColumn < len(m.columns) {
-		col := m.columns[m.activeColumn]
-		if !col.isDoc && col.docCount > 0 {
-			info := fmt.Sprintf("%d docs | limit: %d", col.docCount, m.pageLimit)
-			parts = append(parts, info)
-		}
-		if col.activeQuery != nil {
-			parts = append(parts, "Query: "+col.activeQuery.String())
-		}
-	}
-
-	// Show active filter
-	if m.filterActive && m.filterPattern != "" {
-		parts = append(parts, "Filter: "+m.filterPattern)
-	}
-
-	// Show preview mode
-	if m.previewEnabled {
-		parts = append(parts, "Preview: ON")
-	}
-
-	if len(parts) > 0 {
-		return statusBarStyle.Render(strings.Join(parts, "  "))
-	}
-	return statusBarStyle.Render("")
+	return ""
 }

--- a/pkg/cmd/browse/view.go
+++ b/pkg/cmd/browse/view.go
@@ -138,11 +138,16 @@ func (m Model) View() string {
 
 	// Overlay dialogs — all centered over the main layout
 	if m.overlay == OverlayInfo {
+		scrollHint := "Esc/q: close"
+		if m.infoViewport.TotalLineCount() > m.infoViewport.VisibleLineCount() {
+			pct := m.infoViewport.ScrollPercent() * 100
+			scrollHint = fmt.Sprintf("j/k: scroll  (%0.f%%)  Esc/q: close", pct)
+		}
 		dialogContent := lipgloss.JoinVertical(
 			lipgloss.Left,
-			m.infoContent,
-			"",
-			footerStyle.Render("Esc/q/Enter: close"),
+			m.infoViewport.View(),
+			footerSepStyle.Render(strings.Repeat("─", m.infoViewport.Width)),
+			footerStyle.Render(scrollHint),
 		)
 		dialog := infoDialogStyle.Render(dialogContent)
 		return lipgloss.Place(

--- a/pkg/cmd/browse/view.go
+++ b/pkg/cmd/browse/view.go
@@ -110,14 +110,9 @@ func (m Model) View() string {
 	// Footer: context-sensitive hints or command input
 	var footer string
 	if m.mode == ModeCommand {
-		commandLine := m.commandInput.View()
+		footer = m.commandInput.View()
 		if m.commandResult != "" {
-			footer = lipgloss.JoinVertical(lipgloss.Left,
-				footerStyle.Render(m.commandResult),
-				commandLine,
-			)
-		} else {
-			footer = commandLine
+			separatorLine = "  " + footerStyle.Render(m.commandResult)
 		}
 	} else if m.overlay == OverlayFilter {
 		footer = m.filterInput.View()


### PR DESCRIPTION
## Summary

- **Borderless minimal layout**: Replace bordered Miller columns with a modern design — breadcrumb header (`project › collection › doc`), thin `│` column separators, `▌` cursor accent bar, `·` bullet prefixes, and a muted pastel color palette (slate blue, lavender, sage green, warm sand)
- **UX improvements**: Esc in normal mode shows "Press q to quit" hint instead of quitting; Ctrl+C in command mode cancels instead of quitting; tab completion suggestions replace the separator line instead of shifting the command input; status notifications dismiss on any keypress
- **`:man` command**: Comprehensive scrollable manual documenting all modes, keybindings, commands, tree controls, clipboard operations, and quit behavior
- **`:quit` command**: Explicit quit via command mode
- **Scrollable info overlay**: `:help`, `:marks`, and `:man` output renders in a centered dialog with j/k/PgUp/PgDn scrolling and scroll percentage indicator
- **Layout math fixes**: Extracted shared `itemViewHeight()` helper, fixed double separator subtraction in autoScroll, fixed section header skip mismatch, corrected viewport sizing in update.go

## Test plan

- [x] Launch browse, verify borderless layout renders correctly at various terminal sizes
- [x] Navigate collections and documents — breadcrumb header updates, `▌` cursor shows on active column
- [x] Press Esc in normal mode — should show "Press q to quit", not quit
- [x] Enter command mode (`:`), press Ctrl+C — should return to normal mode
- [x] Type `:` then Tab — suggestions appear on separator line, command input doesn't shift
- [x] Run `:help` — centered dialog with command list, mentions `:man`
- [x] Run `:man` — scrollable manual, j/k scrolls, Esc closes
- [x] Run `:quit` — app exits
- [x] Trigger a notification (e.g. `yy` copy), then press any key — notification dismisses
- [x] Test overlays (Ctrl+g path input, `s` sort dialog, `d` delete confirm, `/` filter) — all centered
- [x] Toggle preview pane (`p`) — renders correctly with `│` separator