### PR TITLE
fix(browse): TUI column isolation and scroll fixes

### DIFF
--- a/pkg/cmd/browse/navigation.go
+++ b/pkg/cmd/browse/navigation.go
@@ -338,6 +338,10 @@ func (m *Model) scrollUp() {
 func (m *Model) addColumn(path string, isDoc bool) {
 	logDebug("addColumn called: path='%s', isDoc=%v, currentColumns=%d", path, isDoc, len(m.columns))
 
+	// Clear any active filter since it only applies to the current column
+	m.filterActive = false
+	m.filterPattern = ""
+
 	// Remove all columns to the right of active column
 	m.columns = m.columns[:m.activeColumn+1]
 
@@ -362,6 +366,10 @@ func (m *Model) removeLastColumn() {
 	if len(m.columns) <= 1 {
 		return
 	}
+
+	// Clear any active filter since it only applies to the current column
+	m.filterActive = false
+	m.filterPattern = ""
 
 	m.columns = m.columns[:len(m.columns)-1]
 	m.activeColumn = len(m.columns) - 1

--- a/pkg/cmd/browse/navigation.go
+++ b/pkg/cmd/browse/navigation.go
@@ -152,9 +152,15 @@ func (m *Model) autoScroll() {
 	col := &m.columns[m.activeColumn]
 	viewHeight := m.itemViewHeight()
 
-	// Calculate column width and inner width (same as in renderColumn)
+	// Calculate column width and inner width (must match renderColumns)
 	visibleCols := getVisibleColumns(m.columns, m.activeColumn)
-	availWidth := m.width - 4 // 2 padding on each side
+	sepWidth := 3
+	margin := 4
+	availWidth := m.width - margin
+	if m.previewEnabled && len(m.previewNodes) > 0 {
+		previewWidth := (m.width - margin) / 3
+		availWidth -= previewWidth + sepWidth
+	}
 	colWidth := calculateColumnWidth(availWidth, len(visibleCols))
 	innerWidth := max(colWidth-2, 1)
 
@@ -207,8 +213,15 @@ func (m *Model) autoScroll() {
 
 					keyStr := node.key
 					valStr := node.valueStr
-					if node.dataType == "string" {
-						valStr = fmt.Sprintf("\"%s\"", valStr)
+					switch node.dataType {
+					case "string":
+						valStr = fmt.Sprintf("%q", valStr)
+					case "null":
+						valStr = "null"
+					case "object":
+						valStr = "{}"
+					case "array":
+						valStr = fmt.Sprintf("[%d]", len(node.children))
 					}
 
 					lineStr := fmt.Sprintf("%s%s%s %s: %s", cursorMarker, prefix, icon, keyStr, valStr)
@@ -230,21 +243,15 @@ func (m *Model) autoScroll() {
 				break
 			}
 		} else {
-			// Linear list logic
+			// Linear list logic — each item is always 1 rendered line
+			// (renderColumn truncates long IDs rather than wrapping)
 			for _, item := range section.items {
-				// Check if this is the cursor item BEFORE incrementing cursorLine
 				if itemIndex == col.cursor {
-					// Found cursor position
 					foundCursor = true
 					break
 				}
-
-				prefix := "  "
-				line := fmt.Sprintf("%s%s", prefix, item.id)
-				wrappedLine := wrapper.Render(line)
-				actualLines := strings.Count(wrappedLine, "\n") + 1
-				cursorLine += actualLines
-
+				_ = item
+				cursorLine++
 				itemIndex++
 			}
 			if foundCursor {

--- a/pkg/cmd/browse/view.go
+++ b/pkg/cmd/browse/view.go
@@ -411,7 +411,11 @@ func (m Model) renderColumn(col Column, width, height int, isActive bool) string
 					selMark = "● "
 				}
 
-				availWidth := max(innerWidth-lipgloss.Width(prefix)-lipgloss.Width(selMark)-1, 5)
+				suffix := ""
+				if item.isMissing {
+					suffix = " (no data)"
+				}
+				availWidth := max(innerWidth-lipgloss.Width(prefix)-lipgloss.Width(selMark)-len(suffix)-1, 5)
 				displayID := item.id
 				if len(displayID) > availWidth {
 					displayID = displayID[:availWidth-3] + "..."
@@ -423,9 +427,9 @@ func (m Model) renderColumn(col Column, width, height int, isActive bool) string
 					dot = "· "
 				}
 
-				line := fmt.Sprintf("%s%s%s%s", prefix, selMark, dot, displayID)
+				line := fmt.Sprintf("%s%s%s%s", prefix, selMark, dot, displayID+suffix)
 				if item.isMissing {
-					line = fmt.Sprintf("%s%s%s%s", prefix, selMark, dot, missingDocStyle.Render(displayID+" (no data)"))
+					line = fmt.Sprintf("%s%s%s%s", prefix, selMark, dot, missingDocStyle.Render(displayID+suffix))
 				}
 
 				if m.mode == ModeVisual && isActive && m.selection.IsSelected(itemIndex) {

--- a/pkg/cmd/browse/view.go
+++ b/pkg/cmd/browse/view.go
@@ -508,7 +508,7 @@ func (m Model) renderColumn(col Column, width, height int, isActive bool) string
 	finalContent := headerBuf.String() + scrolledContent
 
 	// Render with fixed dimensions (no border)
-	return lipgloss.NewStyle().Width(width).Height(height).Render(finalContent)
+	return lipgloss.NewStyle().Width(width).Height(height).MaxHeight(height).Render(finalContent)
 }
 
 // renderTreeNodes renders tree nodes recursively
@@ -615,7 +615,7 @@ func (m Model) renderPreviewPane(width, height int) string {
 	}
 
 	finalContent := headerBuf.String() + strings.Join(lines, "\n")
-	return lipgloss.NewStyle().Width(width).Height(height).Render(finalContent)
+	return lipgloss.NewStyle().Width(width).Height(height).MaxHeight(height).Render(finalContent)
 }
 
 // getFooterHints returns context-sensitive keybinding hints

--- a/pkg/cmd/browse/view.go
+++ b/pkg/cmd/browse/view.go
@@ -407,7 +407,7 @@ func (m Model) renderColumn(col Column, width, height int, isActive bool) string
 				}
 
 				selMark := ""
-				if m.mode == ModeVisual && m.selection.IsSelected(itemIndex) {
+				if m.mode == ModeVisual && isActive && m.selection.IsSelected(itemIndex) {
 					selMark = "● "
 				}
 
@@ -428,7 +428,7 @@ func (m Model) renderColumn(col Column, width, height int, isActive bool) string
 					line = fmt.Sprintf("%s%s%s%s", prefix, selMark, dot, missingDocStyle.Render(displayID+" (no data)"))
 				}
 
-				if m.mode == ModeVisual && m.selection.IsSelected(itemIndex) {
+				if m.mode == ModeVisual && isActive && m.selection.IsSelected(itemIndex) {
 					line = visualSelectedStyle.Render(line)
 				} else if itemIndex == col.cursor && isActive {
 					line = selectedItemStyle.Render(line)


### PR DESCRIPTION
## Summary
- Clear column filter when navigating forward or backward so it doesn't bleed into other columns
- Restrict visual mode selection highlighting to the active column only
- Add `MaxHeight` to column and preview pane rendering to prevent content overflow from shifting the entire UI
- Fix cursor drifting off screen on long lists by aligning `autoScroll` line counting with actual rendering (truncated items = 1 line, correct column width with preview pane, `%q` formatting for tree node strings)

## Test plan
- [x] Apply a filter (`/`) in a column, navigate forward (`l`/`Enter`) — filter should be cleared
- [x] Navigate back (`h`/`Backspace`) — filter should also be cleared
- [x] Enter visual mode (`v`), select items — only the active column should show selection markers
- [x] Browse a column with many entries — UI should not shift/jump when scrolling
- [x] Browse a collection with "(no data)" documents — cursor should stay visible while scrolling