### PR TITLE
Fix pagination and cursor navigation issues

### DIFF
--- a/pkg/cmd/browse/firestore.go
+++ b/pkg/cmd/browse/firestore.go
@@ -391,12 +391,13 @@ func fetchColumnData(client *firestore.Client, path string, isDoc bool, columnIn
 			}
 		}
 
-		// Count documents in sections
+		// Count queried documents (exclude missing refs and sentinel — docCount
+		// is used as the Firestore query Offset for pagination)
 		totalDocs := 0
 		for _, s := range sections {
 			if s.title == "Documents" {
 				for _, item := range s.items {
-					if item.path != "__load_more__" {
+					if item.path != "__load_more__" && !item.isMissing {
 						totalDocs++
 					}
 				}

--- a/pkg/cmd/browse/navigation.go
+++ b/pkg/cmd/browse/navigation.go
@@ -319,6 +319,12 @@ func (m *Model) scrollDown() {
 	}
 
 	col.scrollOffset += pageSize
+
+	totalItems := m.getAllItemsCount(*col)
+	col.cursor += pageSize
+	if col.cursor >= totalItems {
+		col.cursor = totalItems - 1
+	}
 }
 
 // scrollUp scrolls the active column up by half a page
@@ -338,6 +344,11 @@ func (m *Model) scrollUp() {
 	col.scrollOffset -= pageSize
 	if col.scrollOffset < 0 {
 		col.scrollOffset = 0
+	}
+
+	col.cursor -= pageSize
+	if col.cursor < 0 {
+		col.cursor = 0
 	}
 }
 


### PR DESCRIPTION
## Summary
Fix two critical pagination and cursor navigation bugs in the browse column view.

## Changes

### 1. Fix cursor drifting on page up/down
When using page up/down keybinds, the viewport would scroll but the cursor would stay at the last visible item instead of moving together with the view. This created a confusing UX where the selected item would jump around unexpectedly.

**Fix:** Modified `scrollDown()` and `scrollUp()` in navigation.go to move the cursor by the same page size (half-page) as the viewport, keeping them in sync. The cursor position is properly bounded to the total item count.

### 2. Fix "load more" appearing to do nothing
When selecting "Load more..." in a collection column, the pagination would silently fail - the sentinel would disappear but no new documents would appear. 

**Root cause:** The `DocumentRefs()` API returns all document references in a collection (including those on subsequent pages). These extra refs were being added as "missing" items to the Documents section, inflating the `docCount` value used as the Firestore query offset. When "load more" was triggered, this inflated offset would skip past all remaining documents, causing the query to return zero results.

**Fix:** Modified the `docCount` calculation in `fetchColumnData()` to exclude `isMissing` items. Now the offset only reflects documents from actual query results, allowing pagination to work correctly.

## Testing
- Verified page up/down now moves cursor and viewport together
- Verified "Load more..." sentinel triggers a new fetch with correct offset
- Cursor bounds check prevents going past last item