### PR TITLE
chore(ci): improve release automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,29 +1,59 @@
 name: Release
 
 on:
-  release:
-    types: [created]
+  push:
+    tags:
+      - 'v*'
 
 permissions:
+  attestations: write
+  artifact-metadata: write
   contents: write
+  id-token: write
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
+      with:
+        go-version-file: go.mod
+        cache: true
+
+    - name: Install cosign
+      uses: sigstore/cosign-installer@v4
+
+    - name: Install Syft
+      id: syft
+      uses: anchore/sbom-action/download-syft@v0
+
+    - name: Generate Homebrew tap token
+      id: tap-token
+      uses: actions/create-github-app-token@v3
+      with:
+        app-id: ${{ vars.HOMEBREW_TAP_APP_ID }}
+        private-key: ${{ secrets.HOMEBREW_TAP_APP_PRIVATE_KEY }}
+        owner: gugahoi
+        repositories: homebrew-tap
 
     - name: Release
-      uses: goreleaser/goreleaser-action@v6
+      uses: goreleaser/goreleaser-action@v7
       with:
         distribution: goreleaser
         version: '~> v2'
-        args: release --clean
+        args: release --clean --fail-fast
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        HOMEBREW_TAP_GITHUB_TOKEN: ${{ steps.tap-token.outputs.token }}
+        SYFT_CMD: ${{ steps.syft.outputs.cmd }}
+
+    - name: Attest release artifacts
+      uses: actions/attest@v4
+      with:
+        subject-checksums: dist/checksums.txt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,35 @@
+name: Test
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
+
+    - name: Set up Go
+      uses: actions/setup-go@v6
+      with:
+        go-version-file: go.mod
+        cache: true
+
+    - name: Test
+      run: go test ./...
+
+    - name: Check GoReleaser config
+      uses: goreleaser/goreleaser-action@v7
+      with:
+        distribution: goreleaser
+        version: '~> v2'
+        args: check

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,20 +3,34 @@
 
 version: 2
 
+metadata:
+  mod_timestamp: '{{ .CommitTimestamp }}'
+
+project_name: firestore
+
 before:
   hooks:
     - go mod download
 
 builds:
-  - env:
+  - id: firestore
+    env:
       - CGO_ENABLED=0
+    flags:
+      - -trimpath
+    ldflags:
+      - -s -w -buildid=
     goos:
       - linux
       - windows
       - darwin
+    goarch:
+      - amd64
+      - arm64
 
 archives:
-  - format: tar.gz
+  - formats:
+      - tar.gz
     # this name template makes the OS and Arch compatible with the results of `uname`.
     name_template: >-
       {{ .ProjectName }}_
@@ -28,7 +42,44 @@ archives:
     # use zip for windows archives
     format_overrides:
       - goos: windows
-        format: zip
+        formats:
+          - zip
+
+checksum:
+  name_template: 'checksums.txt'
+
+signs:
+  - cmd: cosign
+    signature: '${artifact}.sigstore.json'
+    args:
+      - sign-blob
+      - '--bundle=${signature}'
+      - '${artifact}'
+      - --yes
+    artifacts: checksum
+
+sboms:
+  - cmd: '{{ .Env.SYFT_CMD }}'
+    artifacts: archive
+
+homebrew_casks:
+  - name: firestore
+    ids:
+      - default
+    repository:
+      owner: gugahoi
+      name: homebrew-tap
+      token: '{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}'
+    homepage: https://github.com/gugahoi/firestore
+    description: Command line utility to facilitate operations with Firestore
+    binaries:
+      - firestore
+    hooks:
+      post:
+        install: |
+          if OS.mac?
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/firestore"]
+          end
 
 changelog:
   sort: asc


### PR DESCRIPTION
## Summary
- Move releases to tag-triggered GoReleaser publishing with current action versions and Go version detection from go.mod.
- Add PR/main validation for Go tests and GoReleaser config checks.
- Add release checksums, cosign signing, SBOM generation, GitHub artifact attestations, and Homebrew tap publishing via a short-lived GitHub App token.

## Validation
- goreleaser check
- go test ./...