### PR TITLE
fix(browse): hide preview pane when active column is a document

### DIFF
--- a/pkg/cmd/browse/navigation.go
+++ b/pkg/cmd/browse/navigation.go
@@ -108,6 +108,20 @@ func (m *Model) getAllItemsCount(col Column) int {
 	return count
 }
 
+// shouldShowPreview reports whether the preview pane should be rendered.
+// Preview is a collection-only feature: when the active column is itself a
+// document, the doc's contents already fill that column, so rendering the
+// pane would duplicate it.
+func (m *Model) shouldShowPreview() bool {
+	if !m.previewEnabled || len(m.previewNodes) == 0 {
+		return false
+	}
+	if m.activeColumn >= len(m.columns) {
+		return false
+	}
+	return !m.columns[m.activeColumn].isDoc
+}
+
 // moveCursor moves the cursor in the active column
 func (m *Model) moveCursor(delta int) {
 	if m.activeColumn >= len(m.columns) {
@@ -157,7 +171,7 @@ func (m *Model) autoScroll() {
 	sepWidth := 3
 	margin := 4
 	availWidth := m.width - margin
-	if m.previewEnabled && len(m.previewNodes) > 0 {
+	if m.shouldShowPreview() {
 		previewWidth := (m.width - margin) / 3
 		availWidth -= previewWidth + sepWidth
 	}

--- a/pkg/cmd/browse/preview_test.go
+++ b/pkg/cmd/browse/preview_test.go
@@ -1,0 +1,71 @@
+package browse
+
+import "testing"
+
+func TestShouldShowPreview(t *testing.T) {
+	previewNodes := []ListItem{{path: "users/abc", isDoc: true}}
+
+	tests := []struct {
+		name           string
+		previewEnabled bool
+		previewNodes   []ListItem
+		columns        []Column
+		activeColumn   int
+		want           bool
+	}{
+		{
+			name:           "preview disabled",
+			previewEnabled: false,
+			previewNodes:   previewNodes,
+			columns:        []Column{{path: "users", isDoc: false}},
+			activeColumn:   0,
+			want:           false,
+		},
+		{
+			name:           "no preview nodes",
+			previewEnabled: true,
+			previewNodes:   nil,
+			columns:        []Column{{path: "users", isDoc: false}},
+			activeColumn:   0,
+			want:           false,
+		},
+		{
+			name:           "active column is a collection",
+			previewEnabled: true,
+			previewNodes:   previewNodes,
+			columns:        []Column{{path: "users", isDoc: false}},
+			activeColumn:   0,
+			want:           true,
+		},
+		{
+			name:           "active column is a document",
+			previewEnabled: true,
+			previewNodes:   previewNodes,
+			columns:        []Column{{path: "users", isDoc: false}, {path: "users/abc", isDoc: true}},
+			activeColumn:   1,
+			want:           false,
+		},
+		{
+			name:           "active column out of range",
+			previewEnabled: true,
+			previewNodes:   previewNodes,
+			columns:        []Column{{path: "users", isDoc: false}},
+			activeColumn:   5,
+			want:           false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &Model{
+				previewEnabled: tt.previewEnabled,
+				previewNodes:   tt.previewNodes,
+				columns:        tt.columns,
+				activeColumn:   tt.activeColumn,
+			}
+			if got := m.shouldShowPreview(); got != tt.want {
+				t.Errorf("shouldShowPreview() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/cmd/browse/view.go
+++ b/pkg/cmd/browse/view.go
@@ -296,7 +296,7 @@ func (m Model) renderColumns() string {
 
 	previewWidth := 0
 	availWidth := m.width - margin
-	if m.previewEnabled && len(m.previewNodes) > 0 {
+	if m.shouldShowPreview() {
 		previewWidth = (m.width - margin) / 3
 		availWidth -= previewWidth + sepWidth
 	}
@@ -318,7 +318,7 @@ func (m Model) renderColumns() string {
 	}
 
 	// Add preview pane if enabled
-	if m.previewEnabled && previewWidth > 0 && len(m.previewNodes) > 0 {
+	if previewWidth > 0 && m.shouldShowPreview() {
 		parts = append(parts, verticalSeparator(height))
 		previewCol := m.renderPreviewPane(previewWidth, height)
 		parts = append(parts, previewCol)


### PR DESCRIPTION
## Problem

In TUI browse mode, when the preview window is open and a document is opened, the layout showed **two columns with identical contents** — the document column and the preview pane both rendering the same data.

## Root cause

The preview pane is meant to show the document under the cursor *while browsing a collection*. When you press Enter to open that document, it becomes its own column, but `previewPath`/`previewNodes` were never cleared — so both the active document column and the preview pane rendered the same tree.

## Fix

Add a `shouldShowPreview()` guard that renders the preview pane only when the active column is a **collection** (preview is a collection-only feature). All three preview render/layout sites now use this single source of truth so they can't drift out of sync.

Chosen over clearing preview state on Enter: the back-navigation handler doesn't re-fetch, so clearing would leave a blank preview when returning to the collection. The render guard keeps the state valid, so preview reappears instantly on back-nav.

### Behavior after fix
- Collection + cursor on a doc → preview shows ✓
- Enter into the doc → preview hidden, single column ✓
- `h` back to the collection → preview returns, no re-fetch ✓

## Testing
- Added `TestShouldShowPreview` covering disabled / no-nodes / collection-active / document-active / out-of-range cases
- `go build ./...` and `go test ./pkg/cmd/browse/` pass