### PR TITLE
feat(browse): rename/move documents in TUI

### DIFF
--- a/pkg/cmd/browse/command.go
+++ b/pkg/cmd/browse/command.go
@@ -159,6 +159,20 @@ func initCommandRegistry() *CommandRegistry {
 		Handler:     cmdAdd,
 	})
 
+	r.Register(Command{
+		Name:        "rename",
+		Description: "Rename or move a document (copy to new path, delete old)",
+		Usage:       ":rename <path>",
+		Handler:     cmdRename,
+	})
+
+	r.Register(Command{
+		Name:        "mv",
+		Description: "Alias for :rename",
+		Usage:       ":mv <path>",
+		Handler:     cmdRename,
+	})
+
 	return r
 }
 
@@ -216,6 +230,7 @@ DOCUMENT OPERATIONS
 
   e               Edit document (opens $EDITOR)
   d               Delete document (with confirmation)
+  R               Rename / move document (copy to new path, delete old)
   r               Refresh current column
   p               Toggle preview pane
 
@@ -259,6 +274,9 @@ COMMANDS
   :set limit <n>          Set pagination limit (default: 50)
   :export json|ndjson [f] Export documents (to file or clipboard)
   :add [id]               Create a new document
+  :rename <path>          Rename / move a document (bare name = same
+                          collection; path with / = absolute from root)
+  :mv <path>              Alias for :rename
   :marks                  List all bookmarks
 
   Tab in command mode autocompletes command names.
@@ -390,6 +408,43 @@ func cmdAdd(m *Model, args []string) (string, error) {
 	}
 
 	m.pendingEditor = startAddCmd(m.client, col.path, docID, col.availableFields, m.activeColumn)
+	return "", nil
+}
+
+func cmdRename(m *Model, args []string) (string, error) {
+	if len(args) == 0 {
+		return "", fmt.Errorf("usage: :rename <path>")
+	}
+
+	if m.activeColumn >= len(m.columns) {
+		return "", fmt.Errorf("no active column")
+	}
+
+	col := m.columns[m.activeColumn]
+	var src string
+	var fromDocView bool
+
+	if col.isDoc {
+		src = col.path
+		fromDocView = true
+	} else {
+		item := m.getSelectedItem()
+		if item == nil || !item.isDoc {
+			return "", fmt.Errorf("select a document to rename")
+		}
+		src = item.path
+		fromDocView = false
+	}
+
+	dst, err := resolveRenameTarget(src, strings.Join(args, " "))
+	if err != nil {
+		return "", err
+	}
+
+	m.renameSrc = src
+	m.renameFromDocView = fromDocView
+	m.loading = true
+	m.pendingCmd = prepareRename(m.client, src, dst, fromDocView)
 	return "", nil
 }
 

--- a/pkg/cmd/browse/model.go
+++ b/pkg/cmd/browse/model.go
@@ -29,6 +29,8 @@ const (
 	OverlayDeleteConfirm
 	OverlayFilter
 	OverlayInfo
+	OverlayRename
+	OverlayRenameConfirm
 )
 
 func (m Mode) String() string {
@@ -67,6 +69,7 @@ type Model struct {
 	commandResult   string
 	pendingFetch    *pendingFetchCmd
 	pendingEditor   tea.Cmd
+	pendingCmd      tea.Cmd
 	pendingQuit     bool
 
 	// Sort dialog
@@ -106,6 +109,11 @@ type Model struct {
 	deletePath        string // Path of document pending deletion
 	deleteFromDocView bool   // Whether delete was initiated from a document column
 	bulkDeletePaths   []string // Paths for bulk delete in visual mode
+
+	// Rename / move
+	renameSrc         string // Source path of document being renamed
+	renameDst         string // Destination path (carried into overwrite confirm)
+	renameFromDocView bool   // Whether rename was initiated from a document column
 
 	// Filter
 	filterInput   textinput.Model

--- a/pkg/cmd/browse/rename.go
+++ b/pkg/cmd/browse/rename.go
@@ -1,0 +1,133 @@
+package browse
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"cloud.google.com/go/firestore"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/gugahoi/firestore/pkg/cmd/document"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// renamePreparedMsg is emitted once the pre-flight checks (subcollections,
+// destination existence) have completed successfully.
+type renamePreparedMsg struct {
+	src         string
+	dst         string
+	destExists  bool
+	fromDocView bool
+}
+
+// renamedMsg is emitted once the document has been copied to its destination
+// and the source has been deleted.
+type renamedMsg struct {
+	src         string
+	dst         string
+	fromDocView bool
+}
+
+// renameRefusedMsg is emitted when a rename is rejected by a pre-flight guard
+// (e.g. the source has subcollections). It surfaces as a transient status
+// message rather than a sticky error.
+type renameRefusedMsg struct {
+	reason string
+}
+
+// resolveRenameTarget computes the destination path for a rename given the
+// source document path and the user's input. A bare name (no "/") is a sibling
+// rename within the same collection; an input containing "/" is treated as an
+// absolute document path from the root.
+func resolveRenameTarget(source, input string) (string, error) {
+	input = strings.TrimSpace(input)
+	if input == "" {
+		return "", fmt.Errorf("destination required")
+	}
+
+	src := strings.Trim(source, "/")
+
+	var dst string
+	if strings.Contains(input, "/") {
+		dst = strings.Trim(input, "/")
+		segments := strings.Split(dst, "/")
+		if len(segments)%2 != 0 {
+			return "", fmt.Errorf("destination must be a document path (even number of segments): %s", dst)
+		}
+		for _, s := range segments {
+			if s == "" {
+				return "", fmt.Errorf("destination has an empty path segment: %s", dst)
+			}
+		}
+	} else {
+		idx := strings.LastIndex(src, "/")
+		if idx < 0 {
+			return "", fmt.Errorf("invalid source path: %s", source)
+		}
+		dst = src[:idx+1] + input
+	}
+
+	if dst == src {
+		return "", fmt.Errorf("source and destination are the same")
+	}
+	return dst, nil
+}
+
+// prepareRename runs the pre-flight checks: it refuses to rename a document
+// that has subcollections (a phantom subcollection-only source is caught here
+// too) and reports whether the destination already exists so the caller can
+// confirm an overwrite.
+func prepareRename(client *firestore.Client, src, dst string, fromDocView bool) tea.Cmd {
+	return func() tea.Msg {
+		ctx := context.Background()
+		srcRef := client.Doc(strings.TrimPrefix(src, "/"))
+
+		hasSub, err := document.HasSubcollections(ctx, srcRef)
+		if err != nil {
+			return errorMsg{err: fmt.Errorf("failed to check subcollections: %w", err)}
+		}
+		if hasSub {
+			return renameRefusedMsg{reason: "cannot rename: document has subcollections (not yet supported)"}
+		}
+
+		dstRef := client.Doc(strings.TrimPrefix(dst, "/"))
+		snap, err := dstRef.Get(ctx)
+		destExists := false
+		if err != nil {
+			if status.Code(err) != codes.NotFound {
+				return errorMsg{err: fmt.Errorf("failed to check destination: %w", err)}
+			}
+		} else {
+			destExists = snap.Exists()
+		}
+
+		return renamePreparedMsg{src: src, dst: dst, destExists: destExists, fromDocView: fromDocView}
+	}
+}
+
+// executeRename copies the source document to the destination, then deletes the
+// source. The copy happens first: if it fails, the source is left untouched and
+// nothing is deleted.
+func executeRename(client *firestore.Client, src, dst string, fromDocView bool) tea.Cmd {
+	return func() tea.Msg {
+		ctx := context.Background()
+		srcRef := client.Doc(strings.TrimPrefix(src, "/"))
+
+		snap, err := srcRef.Get(ctx)
+		if err != nil {
+			return errorMsg{err: fmt.Errorf("failed to read source document: %w", err)}
+		}
+
+		dstRef := client.Doc(strings.TrimPrefix(dst, "/"))
+		if _, err := dstRef.Set(ctx, snap.Data()); err != nil {
+			return errorMsg{err: fmt.Errorf("failed to write destination: %w", err)}
+		}
+
+		if _, err := srcRef.Delete(ctx); err != nil {
+			return errorMsg{err: fmt.Errorf("copied to %s but failed to delete source %s: %w", dst, src, err)}
+		}
+
+		return renamedMsg{src: src, dst: dst, fromDocView: fromDocView}
+	}
+}

--- a/pkg/cmd/browse/rename_integration_test.go
+++ b/pkg/cmd/browse/rename_integration_test.go
@@ -1,0 +1,137 @@
+package browse
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"cloud.google.com/go/firestore"
+	"github.com/gugahoi/firestore/pkg/cmd/document"
+)
+
+// These tests run only against a Firestore emulator. Set FIRESTORE_EMULATOR_HOST
+// (e.g. localhost:8765) before running them.
+func emulatorClient(t *testing.T) *firestore.Client {
+	t.Helper()
+	if os.Getenv("FIRESTORE_EMULATOR_HOST") == "" {
+		t.Skip("FIRESTORE_EMULATOR_HOST not set; skipping emulator integration test")
+	}
+	client, err := firestore.NewClient(context.Background(), "test-project")
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+	t.Cleanup(func() { client.Close() })
+	return client
+}
+
+func TestExecuteRename_SimpleRename(t *testing.T) {
+	client := emulatorClient(t)
+	ctx := context.Background()
+
+	src := "users/alice"
+	dst := "users/alice2"
+	data := map[string]interface{}{"name": "Alice", "age": int64(30)}
+	if _, err := client.Doc(src).Set(ctx, data); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	msg := executeRename(client, src, dst, false)()
+	if _, ok := msg.(renamedMsg); !ok {
+		t.Fatalf("expected renamedMsg, got %#v", msg)
+	}
+
+	// Source gone.
+	if _, err := client.Doc(src).Get(ctx); err == nil {
+		t.Errorf("source %s still exists after rename", src)
+	}
+	// Destination has the same data.
+	snap, err := client.Doc(dst).Get(ctx)
+	if err != nil {
+		t.Fatalf("destination %s missing: %v", dst, err)
+	}
+	if got := snap.Data()["name"]; got != "Alice" {
+		t.Errorf("destination name = %v, want Alice", got)
+	}
+}
+
+func TestExecuteRename_CrossCollectionMove(t *testing.T) {
+	client := emulatorClient(t)
+	ctx := context.Background()
+
+	src := "users/bob"
+	dst := "archive/bob"
+	if _, err := client.Doc(src).Set(ctx, map[string]interface{}{"name": "Bob"}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	if _, ok := executeRename(client, src, dst, true)().(renamedMsg); !ok {
+		t.Fatal("expected renamedMsg")
+	}
+
+	if _, err := client.Doc(src).Get(ctx); err == nil {
+		t.Errorf("source %s still exists", src)
+	}
+	if _, err := client.Doc(dst).Get(ctx); err != nil {
+		t.Errorf("destination %s missing: %v", dst, err)
+	}
+}
+
+func TestPrepareRename_DetectsExistingDestination(t *testing.T) {
+	client := emulatorClient(t)
+	ctx := context.Background()
+
+	src := "users/carol"
+	dst := "users/dave"
+	if _, err := client.Doc(src).Set(ctx, map[string]interface{}{"v": 1}); err != nil {
+		t.Fatalf("seed src: %v", err)
+	}
+	if _, err := client.Doc(dst).Set(ctx, map[string]interface{}{"v": 2}); err != nil {
+		t.Fatalf("seed dst: %v", err)
+	}
+
+	msg := prepareRename(client, src, dst, false)()
+	prepared, ok := msg.(renamePreparedMsg)
+	if !ok {
+		t.Fatalf("expected renamePreparedMsg, got %#v", msg)
+	}
+	if !prepared.destExists {
+		t.Error("expected destExists=true for existing destination")
+	}
+
+	// Free destination reports destExists=false.
+	msg2 := prepareRename(client, src, "users/free-slot", false)()
+	prepared2, ok := msg2.(renamePreparedMsg)
+	if !ok {
+		t.Fatalf("expected renamePreparedMsg, got %#v", msg2)
+	}
+	if prepared2.destExists {
+		t.Error("expected destExists=false for free destination")
+	}
+}
+
+func TestPrepareRename_RefusesSubcollections(t *testing.T) {
+	client := emulatorClient(t)
+	ctx := context.Background()
+
+	src := "users/eve"
+	if _, err := client.Doc(src).Set(ctx, map[string]interface{}{"name": "Eve"}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if _, err := client.Doc(src + "/orders/o1").Set(ctx, map[string]interface{}{"total": 10}); err != nil {
+		t.Fatalf("seed subcollection: %v", err)
+	}
+
+	msg := prepareRename(client, src, "users/eve2", false)()
+	if _, ok := msg.(renameRefusedMsg); !ok {
+		t.Fatalf("expected renameRefusedMsg for doc with subcollections, got %#v", msg)
+	}
+
+	// HasSubcollections directly.
+	has, err := document.HasSubcollections(ctx, client.Doc(src))
+	if err != nil {
+		t.Fatalf("HasSubcollections: %v", err)
+	}
+	if !has {
+		t.Error("HasSubcollections = false, want true")
+	}
+}

--- a/pkg/cmd/browse/rename_test.go
+++ b/pkg/cmd/browse/rename_test.go
@@ -1,0 +1,98 @@
+package browse
+
+import "testing"
+
+func TestResolveRenameTarget(t *testing.T) {
+	tests := []struct {
+		name    string
+		source  string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:   "bare name renames within same collection",
+			source: "users/abc",
+			input:  "xyz",
+			want:   "users/xyz",
+		},
+		{
+			name:   "bare name in nested collection",
+			source: "users/abc/orders/o1",
+			input:  "o2",
+			want:   "users/abc/orders/o2",
+		},
+		{
+			name:   "slash path is absolute from root",
+			source: "users/abc",
+			input:  "archive/abc",
+			want:   "archive/abc",
+		},
+		{
+			name:   "leading slash is trimmed",
+			source: "users/abc",
+			input:  "/archive/abc",
+			want:   "archive/abc",
+		},
+		{
+			name:   "source leading slash is handled",
+			source: "/users/abc",
+			input:  "xyz",
+			want:   "users/xyz",
+		},
+		{
+			name:   "bare name without slash stays a sibling rename",
+			source: "users/abc",
+			input:  "archive",
+			want:   "users/archive",
+		},
+		{
+			name:    "odd-segment slash path is rejected",
+			source:  "users/abc",
+			input:   "archive/old/extra",
+			wantErr: true,
+		},
+		{
+			name:    "empty input is rejected",
+			source:  "users/abc",
+			input:   "   ",
+			wantErr: true,
+		},
+		{
+			name:    "empty interior segment is rejected",
+			source:  "users/abc",
+			input:   "a//b/c",
+			wantErr: true,
+		},
+		{
+			name:    "same destination is rejected (bare)",
+			source:  "users/abc",
+			input:   "abc",
+			wantErr: true,
+		},
+		{
+			name:    "same destination is rejected (absolute)",
+			source:  "users/abc",
+			input:   "users/abc",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolveRenameTarget(tt.source, tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil (result %q)", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("resolveRenameTarget(%q, %q) = %q, want %q", tt.source, tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/cmd/browse/update.go
+++ b/pkg/cmd/browse/update.go
@@ -321,6 +321,49 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, clearStatusAfterDelay()
 
+	case renameRefusedMsg:
+		m.loading = false
+		m.statusMsg = msg.reason
+		m.statusMsgTime = time.Now()
+		return m, clearStatusAfterDelay()
+
+	case renamePreparedMsg:
+		if msg.destExists {
+			// Destination already exists — confirm the overwrite.
+			m.renameSrc = msg.src
+			m.renameDst = msg.dst
+			m.renameFromDocView = msg.fromDocView
+			m.loading = false
+			m.overlay = OverlayRenameConfirm
+			return m, nil
+		}
+		// Destination is free — proceed with the rename.
+		return m, executeRename(m.client, msg.src, msg.dst, msg.fromDocView)
+
+	case renamedMsg:
+		m.loading = false
+
+		if msg.fromDocView {
+			// Rename was from a document column — the open path no longer
+			// exists, so go back to the parent collection.
+			m.removeLastColumn()
+		}
+
+		m.statusMsg = fmt.Sprintf("Renamed to %s", msg.dst)
+		m.statusMsgTime = time.Now()
+
+		// Refresh the now-active column so the change is reflected.
+		if m.activeColumn < len(m.columns) {
+			col := m.columns[m.activeColumn]
+			sortField, sortDir := m.getSortParams(col.path)
+			m.loading = true
+			return m, tea.Batch(
+				fetchColumnData(m.client, col.path, col.isDoc, m.activeColumn, sortField, sortDir, withLimit(m.pageLimit)),
+				clearStatusAfterDelay(),
+			)
+		}
+		return m, clearStatusAfterDelay()
+
 	}
 
 	return m, nil
@@ -654,6 +697,35 @@ func (m Model) handleKeyPress(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.deletePath = docPath
 		m.overlay = OverlayDeleteConfirm
 		return m, nil
+
+	case "R":
+		if m.activeColumn >= len(m.columns) {
+			return m, nil
+		}
+
+		col := m.columns[m.activeColumn]
+		var srcPath string
+
+		if col.isDoc {
+			srcPath = col.path
+			m.renameFromDocView = true
+		} else {
+			item := m.getSelectedItem()
+			if item == nil || !item.isDoc {
+				m.statusMsg = "Select a document to rename"
+				m.statusMsgTime = time.Now()
+				return m, clearStatusAfterDelay()
+			}
+			srcPath = item.path
+			m.renameFromDocView = false
+		}
+
+		m.renameSrc = srcPath
+		m.overlay = OverlayRename
+		m.textInput.SetValue(srcPath)
+		m.textInput.CursorEnd()
+		m.textInput.Focus()
+		return m, textinput.Blink
 	}
 
 	return m, nil
@@ -751,6 +823,51 @@ func (m Model) handleOverlay(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.deletePath = ""
 			m.deleteFromDocView = false
 			m.bulkDeletePaths = nil
+			m.overlay = OverlayNone
+			return m, nil
+		}
+		return m, nil
+
+	case OverlayRename:
+		switch msg.String() {
+		case "enter":
+			input := m.textInput.Value()
+			m.overlay = OverlayNone
+			m.textInput.Blur()
+			m.textInput.Reset()
+
+			dst, err := resolveRenameTarget(m.renameSrc, input)
+			if err != nil {
+				m.renameSrc = ""
+				m.statusMsg = fmt.Sprintf("Error: %s", err)
+				m.statusMsgTime = time.Now()
+				return m, clearStatusAfterDelay()
+			}
+
+			m.loading = true
+			return m, prepareRename(m.client, m.renameSrc, dst, m.renameFromDocView)
+		case "esc":
+			m.overlay = OverlayNone
+			m.textInput.Blur()
+			m.textInput.Reset()
+			m.renameSrc = ""
+			return m, nil
+		}
+		m.textInput, cmd = m.textInput.Update(msg)
+		return m, cmd
+
+	case OverlayRenameConfirm:
+		switch msg.String() {
+		case "y", "enter":
+			m.overlay = OverlayNone
+			src, dst, fromDocView := m.renameSrc, m.renameDst, m.renameFromDocView
+			m.renameSrc = ""
+			m.renameDst = ""
+			m.loading = true
+			return m, executeRename(m.client, src, dst, fromDocView)
+		case "n", "esc", "q":
+			m.renameSrc = ""
+			m.renameDst = ""
 			m.overlay = OverlayNone
 			return m, nil
 		}
@@ -914,6 +1031,13 @@ func (m Model) handleCommandMode(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				fetchColumnData(m.client, pf.path, pf.isDoc, pf.colIndex, pf.sortField, pf.sortDir, pf.opts...),
 				clearStatusAfterDelay(),
 			)
+		}
+
+		// Check if the handler set a generic pending command
+		if m.pendingCmd != nil {
+			pc := m.pendingCmd
+			m.pendingCmd = nil
+			return m, pc
 		}
 
 		return m, clearStatusAfterDelay()

--- a/pkg/cmd/browse/view.go
+++ b/pkg/cmd/browse/view.go
@@ -220,6 +220,43 @@ func (m Model) View() string {
 		)
 	}
 
+	if m.overlay == OverlayRename {
+		dialogContent := lipgloss.JoinVertical(
+			lipgloss.Center,
+			"Rename / move document to:",
+			m.textInput.View(),
+		)
+		dialog := inputDialogStyle.Render(dialogContent)
+		return lipgloss.Place(
+			m.width,
+			m.height,
+			lipgloss.Center,
+			lipgloss.Center,
+			dialog,
+			lipgloss.WithWhitespaceChars(" "),
+			lipgloss.WithWhitespaceForeground(colorGray),
+		)
+	}
+
+	if m.overlay == OverlayRenameConfirm {
+		dialogContent := lipgloss.JoinVertical(
+			lipgloss.Center,
+			errorStyle.Render("Destination exists — overwrite?"),
+			"",
+			m.renameDst,
+			"",
+			footerStyle.Render("y/Enter: confirm  n/Esc: cancel"),
+		)
+		dialog := deleteDialogStyle.Render(dialogContent)
+		return lipgloss.Place(
+			m.width,
+			m.height,
+			lipgloss.Center,
+			lipgloss.Center,
+			dialog,
+		)
+	}
+
 	// Floating status notification
 	if m.statusMsg != "" {
 		notificationStyle := lipgloss.NewStyle().
@@ -633,6 +670,12 @@ func (m Model) getFooterHints() string {
 	if m.overlay == OverlayPathInput {
 		return "Enter: Navigate  Esc: Cancel"
 	}
+	if m.overlay == OverlayRename {
+		return "Enter: Rename  Esc: Cancel"
+	}
+	if m.overlay == OverlayRenameConfirm {
+		return "y/Enter: Overwrite  n/Esc: Cancel"
+	}
 	if m.overlay == OverlayFilter {
 		return "Enter: Confirm filter  Esc: Clear and cancel"
 	}
@@ -643,7 +686,7 @@ func (m Model) getFooterHints() string {
 	case ModeCommand:
 		return "Esc: Normal mode"
 	default:
-		return "j/k ↕  h/l ↔  g/G Top/Bottom  / Filter  s Sort  e Edit  d Del  yy Copy  : Cmd  q Quit"
+		return "j/k ↕  h/l ↔  g/G Top/Bottom  / Filter  s Sort  e Edit  d Del  R Move  yy Copy  : Cmd  q Quit"
 	}
 }
 

--- a/pkg/cmd/document/move.go
+++ b/pkg/cmd/document/move.go
@@ -8,6 +8,7 @@ import (
 	"cloud.google.com/go/firestore"
 	"github.com/gugahoi/firestore/pkg/cmd/keys"
 	"github.com/spf13/cobra"
+	"google.golang.org/api/iterator"
 )
 
 func NewMoveCmd() *cobra.Command {
@@ -24,12 +25,36 @@ func NewMoveCmd() *cobra.Command {
 	return cmd
 }
 
+// HasSubcollections reports whether the document has any subcollections. A
+// document's subcollections are independent of its fields: they are not
+// returned by Get and are not removed by Delete, so a field-only move would
+// silently orphan them.
+func HasSubcollections(ctx context.Context, ref *firestore.DocumentRef) (bool, error) {
+	iter := ref.Collections(ctx)
+	_, err := iter.Next()
+	if err == iterator.Done {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
 // move moves a document from the source to the destination, deleting the
 // source. Can be useful when wanting to rename.
 func move(client *firestore.Client, src, dst string) error {
 	ctx := context.Background()
 
 	srcRef := client.Doc(strings.TrimPrefix(src, "/"))
+
+	hasSub, err := HasSubcollections(ctx, srcRef)
+	if err != nil {
+		return fmt.Errorf("failed to check source subcollections: %v", err)
+	}
+	if hasSub {
+		return fmt.Errorf("cannot move %s: document has subcollections (not yet supported)", src)
+	}
 
 	snap, err := srcRef.Get(ctx)
 	if err != nil {


### PR DESCRIPTION
## What

Adds the ability to rename (and move) a document from the TUI. A rename copies the document to the new path and deletes the original.

- **Bare name** (no `/`) → rename within the same collection.
- **Path with `/`** → treated as an **absolute document path from the root**, so a document can be moved to another collection.

## How to use

- Press **`R`** on a document (either highlighted in a collection column, or the currently-open document column) to open a prefilled rename overlay.
- Or use the command palette: **`:rename <path>`** / **`:mv <path>`**.

## Behavior & safeguards

- **Subcollections**: a document's subcollections are independent of its fields — a field-only copy would silently orphan them (the "phantom document" case from #47). Rename **refuses** documents that have subcollections (transient status message). Recursive copy can be added later. The same guard is added to the CLI `document move` command, which had the same silent-data-loss bug; both now share `document.HasSubcollections`.
- **Overwrite**: if the destination already exists, the user is asked to confirm before overwriting.
- **Ordering**: the copy happens first. If the copy fails, the operation aborts and the source is left untouched — worst case is a harmless duplicate, never data loss.
- **Navigation**: renaming the currently-open document returns to the parent collection and refreshes (mirrors delete).

## Testing

- `resolveRenameTarget` is unit-tested (bare→sibling, slash→absolute, odd/empty-segment rejection, same-path no-op).
- Data operations (`prepareRename`, `executeRename`, `HasSubcollections`) are covered by **emulator integration tests** — simple rename, cross-collection move, destination-exists detection, and subcollection refusal — all verified passing against the Firestore emulator. They skip automatically unless `FIRESTORE_EMULATOR_HOST` is set, so CI is unaffected.
- **Not exercised**: the interactive overlay/key wiring was traced and compiles, but was not driven end-to-end in a live terminal (no headless TUI harness in this repo). The underlying data operations it dispatches are covered by the integration tests above.