### PR TITLE
feat(browse): copy documents in TUI

### DIFF
--- a/pkg/cmd/browse/command.go
+++ b/pkg/cmd/browse/command.go
@@ -173,6 +173,20 @@ func initCommandRegistry() *CommandRegistry {
 		Handler:     cmdRename,
 	})
 
+	r.Register(Command{
+		Name:        "copy",
+		Description: "Copy a document to a new id (blank = auto-generate)",
+		Usage:       ":copy [id|path]",
+		Handler:     cmdCopy,
+	})
+
+	r.Register(Command{
+		Name:        "cp",
+		Description: "Alias for :copy",
+		Usage:       ":cp [id|path]",
+		Handler:     cmdCopy,
+	})
+
 	return r
 }
 
@@ -231,6 +245,7 @@ DOCUMENT OPERATIONS
   e               Edit document (opens $EDITOR)
   d               Delete document (with confirmation)
   R               Rename / move document (copy to new path, delete old)
+  c               Copy document to a new id (prompts; blank = auto-generate)
   r               Refresh current column
   p               Toggle preview pane
 
@@ -277,6 +292,9 @@ COMMANDS
   :rename <path>          Rename / move a document (bare name = same
                           collection; path with / = absolute from root)
   :mv <path>              Alias for :rename
+  :copy [id|path]         Copy a document (no arg = auto id; bare name = same
+                          collection; path with / = absolute from root)
+  :cp [id|path]           Alias for :copy
   :marks                  List all bookmarks
 
   Tab in command mode autocompletes command names.
@@ -445,6 +463,43 @@ func cmdRename(m *Model, args []string) (string, error) {
 	m.renameFromDocView = fromDocView
 	m.loading = true
 	m.pendingCmd = prepareRename(m.client, src, dst, fromDocView)
+	return "", nil
+}
+
+func cmdCopy(m *Model, args []string) (string, error) {
+	if m.activeColumn >= len(m.columns) {
+		return "", fmt.Errorf("no active column")
+	}
+
+	col := m.columns[m.activeColumn]
+	var src string
+	var fromDocView bool
+
+	if col.isDoc {
+		src = col.path
+		fromDocView = true
+	} else {
+		item := m.getSelectedItem()
+		if item == nil || !item.isDoc {
+			return "", fmt.Errorf("select a document to copy")
+		}
+		src = item.path
+		fromDocView = false
+	}
+
+	dst := ""
+	if input := strings.TrimSpace(strings.Join(args, " ")); input != "" {
+		resolved, err := resolveRenameTarget(src, input)
+		if err != nil {
+			return "", err
+		}
+		dst = resolved
+	}
+
+	m.copySrc = src
+	m.copyFromDocView = fromDocView
+	m.loading = true
+	m.pendingCmd = executeCopy(m.client, src, dst, fromDocView)
 	return "", nil
 }
 

--- a/pkg/cmd/browse/copy.go
+++ b/pkg/cmd/browse/copy.go
@@ -1,0 +1,92 @@
+package browse
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"cloud.google.com/go/firestore"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/gugahoi/firestore/pkg/cmd/document"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// copiedMsg is emitted once the source document's field data has been copied
+// into a new document. newPath is the path of the freshly created document and
+// hadSubcollections reports whether the source had subcollections (which are
+// not copied) so the caller can surface a note.
+type copiedMsg struct {
+	newPath           string
+	hadSubcollections bool
+}
+
+// copyRefusedMsg is emitted when a copy is rejected because the explicit
+// destination already exists. It surfaces as a transient status message rather
+// than a sticky error.
+type copyRefusedMsg struct {
+	reason string
+}
+
+// executeCopy copies the source document's field data into a new document. When
+// dst is empty an auto-generated id is allocated in the source's collection;
+// otherwise dst is used and the copy is refused if a document already exists
+// there. Only top-level field data is copied — subcollections are left behind.
+// The source is never modified.
+func executeCopy(client *firestore.Client, src, dst string, fromDocView bool) tea.Cmd {
+	return func() tea.Msg {
+		ctx := context.Background()
+		srcRef := client.Doc(strings.TrimPrefix(src, "/"))
+
+		snap, err := srcRef.Get(ctx)
+		if err != nil {
+			if status.Code(err) == codes.NotFound {
+				// A subcollection-only "phantom" ref has no field data of its
+				// own — there is nothing to copy.
+				return copyRefusedMsg{reason: "cannot copy: document has no data (subcollection-only)"}
+			}
+			return errorMsg{err: fmt.Errorf("failed to read source document: %w", err)}
+		}
+
+		// Subcollections are not copied; note their presence for the status line.
+		hadSub, err := document.HasSubcollections(ctx, srcRef)
+		if err != nil {
+			return errorMsg{err: fmt.Errorf("failed to check subcollections: %w", err)}
+		}
+
+		if dst == "" {
+			// Auto-generated id within the source document's collection.
+			parent := parentCollectionPath(src)
+			if parent == "" {
+				return errorMsg{err: fmt.Errorf("invalid source path: %s", src)}
+			}
+			dstRef := client.Collection(parent).NewDoc()
+			if _, err := dstRef.Set(ctx, snap.Data()); err != nil {
+				return errorMsg{err: fmt.Errorf("failed to write copy: %w", err)}
+			}
+			return copiedMsg{newPath: parent + "/" + dstRef.ID, hadSubcollections: hadSub}
+		}
+
+		// Explicit destination — refuse if something is already there.
+		dstRef := client.Doc(strings.TrimPrefix(dst, "/"))
+		if _, err := dstRef.Create(ctx, snap.Data()); err != nil {
+			if status.Code(err) == codes.AlreadyExists {
+				return copyRefusedMsg{reason: fmt.Sprintf("cannot copy: %s already exists", dst)}
+			}
+			return errorMsg{err: fmt.Errorf("failed to write copy: %w", err)}
+		}
+		return copiedMsg{newPath: strings.Trim(dst, "/"), hadSubcollections: hadSub}
+	}
+}
+
+// parentCollectionPath returns the collection path containing the given
+// document path (everything before the final segment). It returns "" if the
+// path does not contain a collection segment.
+func parentCollectionPath(docPath string) string {
+	p := strings.Trim(docPath, "/")
+	idx := strings.LastIndex(p, "/")
+	if idx < 0 {
+		return ""
+	}
+	return p[:idx]
+}

--- a/pkg/cmd/browse/copy_integration_test.go
+++ b/pkg/cmd/browse/copy_integration_test.go
@@ -1,0 +1,166 @@
+//go:build integration
+
+package browse
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gugahoi/firestore/pkg/cmd/document"
+)
+
+func TestExecuteCopy_AutoID(t *testing.T) {
+	client := emulatorClient(t)
+	ctx := context.Background()
+
+	src := "copy_users/alice"
+	data := map[string]interface{}{"name": "Alice", "age": int64(30)}
+	if _, err := client.Doc(src).Set(ctx, data); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	msg := executeCopy(client, src, "", false)()
+	copied, ok := msg.(copiedMsg)
+	if !ok {
+		t.Fatalf("expected copiedMsg, got %#v", msg)
+	}
+	if copied.newPath == src {
+		t.Fatalf("auto copy reused source path %s", src)
+	}
+	if copied.hadSubcollections {
+		t.Error("hadSubcollections = true, want false")
+	}
+
+	// Source untouched.
+	if _, err := client.Doc(src).Get(ctx); err != nil {
+		t.Errorf("source %s missing after copy: %v", src, err)
+	}
+	// New document has the same data.
+	snap, err := client.Doc(copied.newPath).Get(ctx)
+	if err != nil {
+		t.Fatalf("copy %s missing: %v", copied.newPath, err)
+	}
+	if got := snap.Data()["name"]; got != "Alice" {
+		t.Errorf("copy name = %v, want Alice", got)
+	}
+}
+
+func TestExecuteCopy_ExplicitID(t *testing.T) {
+	client := emulatorClient(t)
+	ctx := context.Background()
+
+	src := "copy_users/bob"
+	dst := "copy_users/bob-copy"
+	if _, err := client.Doc(src).Set(ctx, map[string]interface{}{"name": "Bob"}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	msg := executeCopy(client, src, dst, false)()
+	copied, ok := msg.(copiedMsg)
+	if !ok {
+		t.Fatalf("expected copiedMsg, got %#v", msg)
+	}
+	if copied.newPath != dst {
+		t.Errorf("newPath = %q, want %q", copied.newPath, dst)
+	}
+
+	// Both source and copy exist with the same data.
+	if _, err := client.Doc(src).Get(ctx); err != nil {
+		t.Errorf("source %s missing: %v", src, err)
+	}
+	snap, err := client.Doc(dst).Get(ctx)
+	if err != nil {
+		t.Fatalf("copy %s missing: %v", dst, err)
+	}
+	if got := snap.Data()["name"]; got != "Bob" {
+		t.Errorf("copy name = %v, want Bob", got)
+	}
+}
+
+func TestExecuteCopy_RefusesExistingDestination(t *testing.T) {
+	client := emulatorClient(t)
+	ctx := context.Background()
+
+	src := "copy_users/carol"
+	dst := "copy_users/dave"
+	if _, err := client.Doc(src).Set(ctx, map[string]interface{}{"v": int64(1)}); err != nil {
+		t.Fatalf("seed src: %v", err)
+	}
+	if _, err := client.Doc(dst).Set(ctx, map[string]interface{}{"v": int64(2)}); err != nil {
+		t.Fatalf("seed dst: %v", err)
+	}
+
+	msg := executeCopy(client, src, dst, false)()
+	if _, ok := msg.(copyRefusedMsg); !ok {
+		t.Fatalf("expected copyRefusedMsg for existing destination, got %#v", msg)
+	}
+
+	// Destination is unchanged (not overwritten).
+	snap, err := client.Doc(dst).Get(ctx)
+	if err != nil {
+		t.Fatalf("destination %s missing: %v", dst, err)
+	}
+	if got := snap.Data()["v"]; got != int64(2) {
+		t.Errorf("destination v = %v, want 2 (unchanged)", got)
+	}
+}
+
+func TestExecuteCopy_PhantomDocument(t *testing.T) {
+	client := emulatorClient(t)
+	ctx := context.Background()
+
+	// A "phantom" document: no own fields, only a subcollection. These are
+	// listed as first-class refs in the browser, so a user can select one and
+	// press `c`. Probe what executeCopy does with it.
+	src := "copy_users/ghost"
+	if _, err := client.Doc(src + "/orders/o1").Set(ctx, map[string]interface{}{"total": int64(5)}); err != nil {
+		t.Fatalf("seed subcollection: %v", err)
+	}
+
+	// A phantom source has no field data, so copy is refused with a transient
+	// message rather than a sticky error.
+	msg := executeCopy(client, src, "", false)()
+	if _, ok := msg.(copyRefusedMsg); !ok {
+		t.Fatalf("expected copyRefusedMsg for phantom document, got %#v", msg)
+	}
+}
+
+func TestExecuteCopy_IgnoresSubcollections(t *testing.T) {
+	client := emulatorClient(t)
+	ctx := context.Background()
+
+	src := "copy_users/eve"
+	dst := "copy_users/eve-copy"
+	if _, err := client.Doc(src).Set(ctx, map[string]interface{}{"name": "Eve"}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if _, err := client.Doc(src + "/orders/o1").Set(ctx, map[string]interface{}{"total": int64(10)}); err != nil {
+		t.Fatalf("seed subcollection: %v", err)
+	}
+
+	msg := executeCopy(client, src, dst, false)()
+	copied, ok := msg.(copiedMsg)
+	if !ok {
+		t.Fatalf("expected copiedMsg, got %#v", msg)
+	}
+	if !copied.hadSubcollections {
+		t.Error("hadSubcollections = false, want true")
+	}
+
+	// Field data copied.
+	snap, err := client.Doc(dst).Get(ctx)
+	if err != nil {
+		t.Fatalf("copy %s missing: %v", dst, err)
+	}
+	if got := snap.Data()["name"]; got != "Eve" {
+		t.Errorf("copy name = %v, want Eve", got)
+	}
+	// Subcollection NOT copied.
+	has, err := document.HasSubcollections(ctx, client.Doc(dst))
+	if err != nil {
+		t.Fatalf("check copy subcollections: %v", err)
+	}
+	if has {
+		t.Error("copy has subcollections, want none copied")
+	}
+}

--- a/pkg/cmd/browse/model.go
+++ b/pkg/cmd/browse/model.go
@@ -31,6 +31,7 @@ const (
 	OverlayInfo
 	OverlayRename
 	OverlayRenameConfirm
+	OverlayCopy
 )
 
 func (m Mode) String() string {
@@ -114,6 +115,10 @@ type Model struct {
 	renameSrc         string // Source path of document being renamed
 	renameDst         string // Destination path (carried into overwrite confirm)
 	renameFromDocView bool   // Whether rename was initiated from a document column
+
+	// Copy / duplicate
+	copySrc         string // Source path of document being copied
+	copyFromDocView bool   // Whether copy was initiated from a document column
 
 	// Filter
 	filterInput   textinput.Model

--- a/pkg/cmd/browse/update.go
+++ b/pkg/cmd/browse/update.go
@@ -364,6 +364,40 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, clearStatusAfterDelay()
 
+	case copyRefusedMsg:
+		m.loading = false
+		m.statusMsg = msg.reason
+		m.statusMsgTime = time.Now()
+		return m, clearStatusAfterDelay()
+
+	case copiedMsg:
+		m.loading = false
+
+		status := fmt.Sprintf("Copied to %s", msg.newPath)
+		if msg.hadSubcollections {
+			status += " (subcollections not copied)"
+		}
+		m.statusMsg = status
+		m.statusMsgTime = time.Now()
+
+		// The new sibling lives in the collection column. When copying from a
+		// document column, that collection is one column to the left; the source
+		// still exists, so the column is kept (no removeLastColumn).
+		refreshIdx := m.activeColumn
+		if refreshIdx < len(m.columns) && m.columns[refreshIdx].isDoc {
+			refreshIdx--
+		}
+		if refreshIdx >= 0 && refreshIdx < len(m.columns) {
+			col := m.columns[refreshIdx]
+			sortField, sortDir := m.getSortParams(col.path)
+			m.loading = true
+			return m, tea.Batch(
+				fetchColumnData(m.client, col.path, col.isDoc, refreshIdx, sortField, sortDir, withLimit(m.pageLimit)),
+				clearStatusAfterDelay(),
+			)
+		}
+		return m, clearStatusAfterDelay()
+
 	}
 
 	return m, nil
@@ -726,6 +760,34 @@ func (m Model) handleKeyPress(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.textInput.CursorEnd()
 		m.textInput.Focus()
 		return m, textinput.Blink
+
+	case "c":
+		if m.activeColumn >= len(m.columns) {
+			return m, nil
+		}
+
+		col := m.columns[m.activeColumn]
+		var srcPath string
+
+		if col.isDoc {
+			srcPath = col.path
+			m.copyFromDocView = true
+		} else {
+			item := m.getSelectedItem()
+			if item == nil || !item.isDoc {
+				m.statusMsg = "Select a document to copy"
+				m.statusMsgTime = time.Now()
+				return m, clearStatusAfterDelay()
+			}
+			srcPath = item.path
+			m.copyFromDocView = false
+		}
+
+		m.copySrc = srcPath
+		m.overlay = OverlayCopy
+		m.textInput.SetValue("")
+		m.textInput.Focus()
+		return m, textinput.Blink
 	}
 
 	return m, nil
@@ -851,6 +913,40 @@ func (m Model) handleOverlay(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.textInput.Blur()
 			m.textInput.Reset()
 			m.renameSrc = ""
+			return m, nil
+		}
+		m.textInput, cmd = m.textInput.Update(msg)
+		return m, cmd
+
+	case OverlayCopy:
+		switch msg.String() {
+		case "enter":
+			input := strings.TrimSpace(m.textInput.Value())
+			m.overlay = OverlayNone
+			m.textInput.Blur()
+			m.textInput.Reset()
+
+			dst := ""
+			if input != "" {
+				resolved, err := resolveRenameTarget(m.copySrc, input)
+				if err != nil {
+					m.copySrc = ""
+					m.statusMsg = fmt.Sprintf("Error: %s", err)
+					m.statusMsgTime = time.Now()
+					return m, clearStatusAfterDelay()
+				}
+				dst = resolved
+			}
+
+			src, fromDocView := m.copySrc, m.copyFromDocView
+			m.copySrc = ""
+			m.loading = true
+			return m, executeCopy(m.client, src, dst, fromDocView)
+		case "esc":
+			m.overlay = OverlayNone
+			m.textInput.Blur()
+			m.textInput.Reset()
+			m.copySrc = ""
 			return m, nil
 		}
 		m.textInput, cmd = m.textInput.Update(msg)

--- a/pkg/cmd/browse/view.go
+++ b/pkg/cmd/browse/view.go
@@ -238,6 +238,24 @@ func (m Model) View() string {
 		)
 	}
 
+	if m.overlay == OverlayCopy {
+		dialogContent := lipgloss.JoinVertical(
+			lipgloss.Center,
+			"Copy document — new id (blank = auto):",
+			m.textInput.View(),
+		)
+		dialog := inputDialogStyle.Render(dialogContent)
+		return lipgloss.Place(
+			m.width,
+			m.height,
+			lipgloss.Center,
+			lipgloss.Center,
+			dialog,
+			lipgloss.WithWhitespaceChars(" "),
+			lipgloss.WithWhitespaceForeground(colorGray),
+		)
+	}
+
 	if m.overlay == OverlayRenameConfirm {
 		dialogContent := lipgloss.JoinVertical(
 			lipgloss.Center,


### PR DESCRIPTION
## Summary

Adds a `:copy` command (with `:cp` alias) and a `c` keymap to the browse TUI that duplicate the field data of the currently-selected document into a new document. This complements the existing `:rename`/`R` (copy-then-delete) flow with a non-destructive copy.

## Behavior

- `:copy` with **no argument** → create a copy with an **auto-generated id** in the current collection.
- `:copy <id|path>` → bare name = sibling in the current collection; path with `/` = absolute document path (same semantics as `:rename`, reusing `resolveRenameTarget`).
- `c` key → prompts for the new id; a **blank answer = auto-generate**. Works from both collection view (selected doc) and document view.
- Explicit destination that **already exists → refused** (no overwrite; uses `Create()`).
- Subcollection-only **"phantom" documents** → refused with a transient message (they have no own field data to copy).
- **Subcollections are not copied** — only top-level field data. When the source has subcollections, the success status notes they weren't copied. The source is never modified.

After a copy, the collection column is refreshed so the new document appears (the column is kept, unlike rename which removes it).

## Implementation

- New `pkg/cmd/browse/copy.go` — `executeCopy`, `copiedMsg`/`copyRefusedMsg`, `parentCollectionPath`.
- `command.go` — `cmdCopy`, `:copy`/`:cp` registration, `:man` updated.
- `model.go` — `OverlayCopy` + `copySrc`/`copyFromDocView`.
- `update.go` — `c` keymap, `OverlayCopy` handler, message cases.
- `view.go` — copy prompt dialog.

Reuses existing `resolveRenameTarget`, `document.HasSubcollections`, the `colRef.NewDoc()` auto-id pattern, and the rename overlay/refresh plumbing.

## Testing

- `go build ./...`, `go vet ./...` (with and without the `integration` tag): clean.
- Unit tests pass.
- New emulator-backed integration tests in `copy_integration_test.go` (all passing): auto-id, explicit-id, refuse-existing-destination, phantom-document, ignore-subcollections.