### PR TITLE
feat(document): add edit subcommand

### DIFF
--- a/pkg/cmd/document/edit.go
+++ b/pkg/cmd/document/edit.go
@@ -1,0 +1,179 @@
+package document
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+
+	"cloud.google.com/go/firestore"
+	"github.com/gugahoi/firestore/pkg/cmd/keys"
+	"github.com/spf13/cobra"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func NewEditCmd() *cobra.Command {
+	var set []string
+
+	cmd := &cobra.Command{
+		Use:     "edit <path>",
+		Aliases: []string{"e"},
+		Short:   "edits a document, interactively in $EDITOR or via --set field=value",
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client := cmd.Context().Value(keys.ClientKey).(*firestore.Client)
+			if len(set) > 0 {
+				return editFields(client, args[0], set)
+			}
+			return editInteractive(client, args[0])
+		},
+	}
+
+	cmd.Flags().StringSliceVar(&set, "set", nil, "field=value pair to update (repeatable, e.g. --set age=42 --set address.city=NYC)")
+	return cmd
+}
+
+// editFields partially updates the named fields, leaving all other fields untouched.
+func editFields(client *firestore.Client, path string, sets []string) error {
+	ctx := context.Background()
+
+	updates := make([]firestore.Update, 0, len(sets))
+	for _, s := range sets {
+		u, err := parseSetArg(s)
+		if err != nil {
+			return err
+		}
+		updates = append(updates, u)
+	}
+
+	docRef := client.Doc(strings.TrimPrefix(path, "/"))
+	_, err := docRef.Update(ctx, updates)
+	if err != nil {
+		if status.Code(err) == codes.NotFound {
+			return fmt.Errorf("document not found")
+		}
+		return fmt.Errorf("failed to update document: %v", err)
+	}
+
+	return nil
+}
+
+// editInteractive opens the current document contents in $EDITOR and writes the
+// edited JSON back, replacing the whole document.
+func editInteractive(client *firestore.Client, path string) error {
+	ctx := context.Background()
+
+	docRef := client.Doc(strings.TrimPrefix(path, "/"))
+	snap, err := docRef.Get(ctx)
+	if err != nil {
+		if status.Code(err) == codes.NotFound {
+			return fmt.Errorf("document not found")
+		}
+		return fmt.Errorf("failed to read document: %v", err)
+	}
+
+	editor, err := detectEditor()
+	if err != nil {
+		return err
+	}
+
+	content, err := json.MarshalIndent(snap.Data(), "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to format document: %v", err)
+	}
+
+	tmpFile, err := os.CreateTemp("", "firestore-doc-*.json")
+	if err != nil {
+		return fmt.Errorf("failed to create temp file: %v", err)
+	}
+	defer os.Remove(tmpFile.Name())
+	if _, err := tmpFile.Write(content); err != nil {
+		tmpFile.Close()
+		return fmt.Errorf("failed to write temp file: %v", err)
+	}
+	tmpFile.Close()
+
+	// strings.Fields handles editors with args, e.g. EDITOR="code --wait"
+	parts := strings.Fields(editor)
+	c := exec.Command(parts[0], append(parts[1:], tmpFile.Name())...)
+	c.Stdin, c.Stdout, c.Stderr = os.Stdin, os.Stdout, os.Stderr
+	if err := c.Run(); err != nil {
+		return fmt.Errorf("editor exited with error: %v", err)
+	}
+
+	edited, err := os.ReadFile(tmpFile.Name())
+	if err != nil {
+		return fmt.Errorf("failed to read edited file: %v", err)
+	}
+
+	var data map[string]any
+	if err := json.Unmarshal(edited, &data); err != nil {
+		return fmt.Errorf("invalid JSON: %v", err)
+	}
+
+	if _, err := docRef.Set(ctx, data); err != nil {
+		return fmt.Errorf("failed to save document: %v", err)
+	}
+
+	return nil
+}
+
+// detectEditor finds the user's preferred editor.
+// ponytail: duplicated from browse/editor.go (~12 lines) — browse pulls in Bubble Tea, so
+// importing it here would drag the whole TUI into this lightweight command. Extract to a shared
+// pkg/cmd/editor package if a third caller ever needs it.
+func detectEditor() (string, error) {
+	if editor := os.Getenv("EDITOR"); editor != "" {
+		return editor, nil
+	}
+	if editor := os.Getenv("VISUAL"); editor != "" {
+		return editor, nil
+	}
+	for _, editor := range []string{"vim", "vi", "nano"} {
+		if _, err := exec.LookPath(editor); err == nil {
+			return editor, nil
+		}
+	}
+	return "", fmt.Errorf("no editor found (set $EDITOR)")
+}
+
+// parseSetArg splits a "field=value" pair into a firestore.Update. The field may be a dotted
+// path (e.g. address.city); firestore.Update.Path interprets dots as field-path separators.
+func parseSetArg(s string) (firestore.Update, error) {
+	field, value, found := strings.Cut(s, "=")
+	if !found || field == "" {
+		return firestore.Update{}, fmt.Errorf("invalid --set %q, expected field=value", s)
+	}
+	return firestore.Update{Path: field, Value: parseValue(value)}, nil
+}
+
+// parseValue auto-detects the type of a value string: quoted->string, true/false->bool,
+// [..]->JSON array, numeric->number, anything else->bare string.
+func parseValue(s string) any {
+	if len(s) >= 2 && s[0] == '"' && s[len(s)-1] == '"' {
+		var v string
+		if err := json.Unmarshal([]byte(s), &v); err == nil {
+			return v
+		}
+	}
+	if s == "true" {
+		return true
+	}
+	if s == "false" {
+		return false
+	}
+	if len(s) >= 2 && s[0] == '[' {
+		var arr []any
+		if err := json.Unmarshal([]byte(s), &arr); err == nil {
+			return arr
+		}
+	}
+	if n, err := strconv.ParseFloat(s, 64); err == nil {
+		return n
+	}
+	return s
+}

--- a/pkg/cmd/document/edit_integration_test.go
+++ b/pkg/cmd/document/edit_integration_test.go
@@ -1,0 +1,138 @@
+//go:build integration
+
+package document
+
+import (
+	"context"
+	"os"
+	"reflect"
+	"testing"
+
+	"cloud.google.com/go/firestore"
+)
+
+// These tests run only against a Firestore emulator. Set FIRESTORE_EMULATOR_HOST
+// (e.g. localhost:8765) before running them.
+func emulatorClient(t *testing.T) *firestore.Client {
+	t.Helper()
+	if os.Getenv("FIRESTORE_EMULATOR_HOST") == "" {
+		t.Skip("FIRESTORE_EMULATOR_HOST not set; skipping emulator integration test")
+	}
+	client, err := firestore.NewClient(context.Background(), "test-project")
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+	t.Cleanup(func() { client.Close() })
+	return client
+}
+
+func TestEditFields_PartialMerge(t *testing.T) {
+	client := emulatorClient(t)
+	ctx := context.Background()
+
+	path := "edit_users/alice"
+	seed := map[string]any{
+		"name":  "Alice",
+		"age":   int64(30),
+		"email": "alice@example.com",
+	}
+	if _, err := client.Doc(path).Set(ctx, seed); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	if err := editFields(client, path, []string{"age=31", "active=true"}); err != nil {
+		t.Fatalf("editFields: %v", err)
+	}
+
+	snap, err := client.Doc(path).Get(ctx)
+	if err != nil {
+		t.Fatalf("get after edit: %v", err)
+	}
+	data := snap.Data()
+
+	// Updated fields. Numbers go through parseValue as float64 and read back as
+	// float64 (Firestore preserves the stored double type).
+	if got := data["age"]; got != float64(31) {
+		t.Errorf("age = %v (%T), want float64(31)", got, got)
+	}
+	if got := data["active"]; got != true {
+		t.Errorf("active = %v, want true", got)
+	}
+	// Untouched fields survive the partial merge.
+	if got := data["name"]; got != "Alice" {
+		t.Errorf("name = %v, want Alice (untouched)", got)
+	}
+	if got := data["email"]; got != "alice@example.com" {
+		t.Errorf("email = %v, want alice@example.com (untouched)", got)
+	}
+}
+
+func TestEditFields_DottedPath(t *testing.T) {
+	client := emulatorClient(t)
+	ctx := context.Background()
+
+	path := "edit_users/bob"
+	seed := map[string]any{
+		"address": map[string]any{
+			"city": "LA",
+			"zip":  "90001",
+		},
+	}
+	if _, err := client.Doc(path).Set(ctx, seed); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	if err := editFields(client, path, []string{"address.city=NYC"}); err != nil {
+		t.Fatalf("editFields: %v", err)
+	}
+
+	snap, err := client.Doc(path).Get(ctx)
+	if err != nil {
+		t.Fatalf("get after edit: %v", err)
+	}
+	addr, ok := snap.Data()["address"].(map[string]any)
+	if !ok {
+		t.Fatalf("address = %#v, want map", snap.Data()["address"])
+	}
+	if got := addr["city"]; got != "NYC" {
+		t.Errorf("address.city = %v, want NYC", got)
+	}
+	// Sibling nested field untouched.
+	if got := addr["zip"]; got != "90001" {
+		t.Errorf("address.zip = %v, want 90001 (untouched)", got)
+	}
+}
+
+func TestEditFields_Array(t *testing.T) {
+	client := emulatorClient(t)
+	ctx := context.Background()
+
+	path := "edit_users/carol"
+	if _, err := client.Doc(path).Set(ctx, map[string]any{"name": "Carol"}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	if err := editFields(client, path, []string{`tags=["a","b"]`}); err != nil {
+		t.Fatalf("editFields: %v", err)
+	}
+
+	snap, err := client.Doc(path).Get(ctx)
+	if err != nil {
+		t.Fatalf("get after edit: %v", err)
+	}
+	if got := snap.Data()["tags"]; !reflect.DeepEqual(got, []any{"a", "b"}) {
+		t.Errorf("tags = %#v, want [a b]", got)
+	}
+}
+
+func TestEditFields_NotFound(t *testing.T) {
+	client := emulatorClient(t)
+
+	err := editFields(client, "edit_users/missing", []string{"x=1"})
+	if err == nil {
+		t.Fatal("expected error for missing document, got nil")
+	}
+	if err.Error() != "document not found" {
+		t.Errorf("error = %q, want %q", err.Error(), "document not found")
+	}
+}

--- a/pkg/cmd/document/edit_test.go
+++ b/pkg/cmd/document/edit_test.go
@@ -1,0 +1,44 @@
+package document
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseValue(t *testing.T) {
+	tests := []struct {
+		in   string
+		want any
+	}{
+		{"foo", "foo"},
+		{"42", float64(42)},
+		{"3.14", 3.14},
+		{"true", true},
+		{"false", false},
+		{`["a","b"]`, []any{"a", "b"}},
+		{`"42"`, "42"}, // quotes force a string
+		{"NYC", "NYC"},
+	}
+	for _, tt := range tests {
+		got := parseValue(tt.in)
+		if !reflect.DeepEqual(got, tt.want) {
+			t.Errorf("parseValue(%q) = %#v, want %#v", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestParseSetArg(t *testing.T) {
+	u, err := parseSetArg("address.city=NYC")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if u.Path != "address.city" || u.Value != "NYC" {
+		t.Errorf("parseSetArg = {Path:%q Value:%v}, want {address.city NYC}", u.Path, u.Value)
+	}
+
+	for _, bad := range []string{"noequals", "=value"} {
+		if _, err := parseSetArg(bad); err == nil {
+			t.Errorf("parseSetArg(%q) expected error, got nil", bad)
+		}
+	}
+}

--- a/pkg/cmd/document/root.go
+++ b/pkg/cmd/document/root.go
@@ -15,6 +15,7 @@ func NewDocumentCmd() *cobra.Command {
 		NewAddCmd(),
 		NewCopyCmd(),
 		NewDeleteCmd(),
+		NewEditCmd(),
 		NewGetCmd(),
 		NewListCmd(),
 		NewMoveCmd(),


### PR DESCRIPTION
## Summary
- Add `firestore document edit <path>` (alias `e`) to modify existing documents from the CLI.
- **Interactive mode** (no flags): opens the document's contents as JSON in `$EDITOR` (falls back to `$VISUAL`, then `vim`/`vi`/`nano`); on save, validates and full-replaces the document via `Set`.
- **Non-interactive mode** (`--set field=value`, repeatable): partial-merges only the named fields via firestore `Update`, leaving siblings untouched. Supports dotted paths (`address.city=NYC`) and auto-typed values (number/bool/JSON-array/string; quote to force a string).
- Errors with `document not found` if the document doesn't exist (it's *edit*, not *create*).

## Test plan
- `go build -o firestore .` passes
- `go test ./...` passes (unit tests cover `parseValue` / `parseSetArg`)
- `make integration-test` passes (emulator tests cover partial merge, dotted paths, arrays, and not-found for the non-interactive path)
- Interactive mode is exercised manually (`EDITOR=vim firestore doc edit <path>`); not covered by automated tests since it needs a real editor.

## Notes
- `detectEditor` is a small (~12 line) duplication of the helper in `pkg/cmd/browse/editor.go` — kept local on purpose so this lightweight command doesn't pull in the Bubble Tea TUI dependency. Marked with a `ponytail:` comment noting the extract-to-shared path if a third caller appears.