### PR TITLE
feat(api): add raw Firestore REST API subcommand

### DIFF
--- a/pkg/cmd/api/api.go
+++ b/pkg/cmd/api/api.go
@@ -1,0 +1,205 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/gugahoi/firestore/pkg/cmd/keys"
+	"github.com/spf13/cobra"
+	"golang.org/x/oauth2/google"
+)
+
+const (
+	defaultDatabase = "(default)"
+	liveBaseURL     = "https://firestore.googleapis.com/v1/"
+	datastoreScope  = "https://www.googleapis.com/auth/datastore"
+)
+
+func NewApiCmd() *cobra.Command {
+	var method, input string
+
+	cmd := &cobra.Command{
+		Use:   "api <path>",
+		Short: "make an authenticated request to the Firestore REST API",
+		Long: `Make an authenticated request to the Firestore REST API.
+
+This is an escape hatch for interactions the CLI does not wrap yet (named
+databases, :runQuery, :batchGet, field masks, admin endpoints, ...). It works
+like "gh api": you give a path, it makes the request with the project and
+credentials you already have configured.
+
+Path resolution:
+  - A relative path is expanded under the documents collection of the current
+    project, i.e. "users/u1" becomes
+      projects/<project>/databases/(default)/documents/users/u1
+  - A path starting with "projects/" is sent verbatim (after the /v1/ prefix),
+    for admin, query and other non-document endpoints.
+
+Placeholders (substituted in either form):
+  - {project}  -> the --project (-p) / PROJECT_ID value
+  - {database} -> (default)
+
+Method:
+  - Defaults to GET, or POST when a body is supplied with --input.
+  - Override with -X/--method.
+
+Body:
+  - --input <file> reads the request body from a file.
+  - --input -      reads the request body from STDIN.
+  - A Content-Type of application/json is set automatically when a body is sent.
+
+Authentication:
+  - Uses Application Default Credentials (run 'firestore auth login' first).
+  - When --host (or FIRESTORE_EMULATOR_HOST) points at an emulator, requests go
+    to that host and no real credentials are required.`,
+		Example: `  # Get a document (relative path)
+  firestore api users/u1
+
+  # Create a document from STDIN
+  echo '{"fields":{"name":{"stringValue":"ada"}}}' | firestore api 'users?documentId=u1' -X POST --input -
+
+  # Run a structured query (verbatim path with placeholders)
+  firestore api 'projects/{project}/databases/{database}/documents:runQuery' -X POST --input query.json
+
+  # Delete a document
+  firestore api users/u1 -X DELETE`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			projectID, _ := cmd.Context().Value(keys.ProjectIDKey).(string)
+			return apiCall(cmd.Context(), projectID, args[0], method, input)
+		},
+	}
+
+	cmd.Flags().StringVarP(&method, "method", "X", "", "HTTP method (default GET, or POST when --input is given)")
+	cmd.Flags().StringVar(&input, "input", "", "request body: a file path, or '-' to read STDIN")
+
+	return cmd
+}
+
+func apiCall(ctx context.Context, projectID, path, method, input string) error {
+	body, err := readBody(input)
+	if err != nil {
+		return err
+	}
+
+	base, emulator := baseURL()
+	url := base + resolvePath(projectID, defaultDatabase, path)
+
+	var reader io.Reader
+	if body != nil {
+		reader = bytes.NewReader(body)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, defaultMethod(method, body != nil), url, reader)
+	if err != nil {
+		return fmt.Errorf("failed to build request: %w", err)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	if emulator {
+		req.Header.Set("Authorization", "Bearer owner")
+	} else {
+		ts, err := google.DefaultTokenSource(ctx, datastoreScope)
+		if err != nil {
+			return fmt.Errorf("failed to find credentials (run 'firestore auth login'): %w", err)
+		}
+		tok, err := ts.Token()
+		if err != nil {
+			return fmt.Errorf("failed to get auth token: %w", err)
+		}
+		tok.SetAuthHeader(req)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read response: %w", err)
+	}
+
+	if resp.StatusCode >= 400 {
+		return fmt.Errorf("HTTP %s: %s", resp.Status, strings.TrimSpace(string(respBody)))
+	}
+
+	printResponse(respBody)
+	return nil
+}
+
+// resolvePath expands {project}/{database} placeholders and turns a relative
+// path into a fully-qualified documents path. Paths already starting with
+// "projects/" are returned verbatim.
+func resolvePath(projectID, database, path string) string {
+	path = strings.TrimPrefix(path, "/")
+	path = strings.ReplaceAll(path, "{project}", projectID)
+	path = strings.ReplaceAll(path, "{database}", database)
+	if strings.HasPrefix(path, "projects/") {
+		return path
+	}
+	return fmt.Sprintf("projects/%s/databases/%s/documents/%s", projectID, database, path)
+}
+
+// defaultMethod returns the explicit method (upper-cased) if given, otherwise
+// POST when a body is present and GET otherwise.
+func defaultMethod(method string, hasBody bool) string {
+	if method != "" {
+		return strings.ToUpper(method)
+	}
+	if hasBody {
+		return http.MethodPost
+	}
+	return http.MethodGet
+}
+
+func baseURL() (string, bool) {
+	if h := os.Getenv("FIRESTORE_EMULATOR_HOST"); h != "" {
+		return "http://" + h + "/v1/", true
+	}
+	return liveBaseURL, false
+}
+
+func readBody(input string) ([]byte, error) {
+	switch input {
+	case "":
+		return nil, nil
+	case "-":
+		b, err := io.ReadAll(os.Stdin)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read STDIN: %w", err)
+		}
+		return b, nil
+	default:
+		b, err := os.ReadFile(input)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read input file: %w", err)
+		}
+		return b, nil
+	}
+}
+
+// printResponse pretty-prints JSON, falling back to raw output for non-JSON.
+func printResponse(b []byte) {
+	var v any
+	if err := json.Unmarshal(b, &v); err != nil {
+		os.Stdout.Write(b)
+		if len(b) > 0 && b[len(b)-1] != '\n' {
+			fmt.Println()
+		}
+		return
+	}
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetEscapeHTML(false)
+	enc.SetIndent("", "  ")
+	enc.Encode(v)
+}

--- a/pkg/cmd/api/api_test.go
+++ b/pkg/cmd/api/api_test.go
@@ -1,0 +1,42 @@
+package api
+
+import "testing"
+
+func TestResolvePath(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{"relative", "users/u1", "projects/proj/databases/(default)/documents/users/u1"},
+		{"relative with leading slash", "/users/u1", "projects/proj/databases/(default)/documents/users/u1"},
+		{"relative with query", "users?documentId=u1", "projects/proj/databases/(default)/documents/users?documentId=u1"},
+		{"verbatim passthrough", "projects/other/databases/(default)/documents/users/u1", "projects/other/databases/(default)/documents/users/u1"},
+		{"project placeholder", "projects/{project}/databases/{database}/documents:runQuery", "projects/proj/databases/(default)/documents:runQuery"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := resolvePath("proj", "(default)", tt.path); got != tt.want {
+				t.Errorf("resolvePath(%q) = %q, want %q", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDefaultMethod(t *testing.T) {
+	tests := []struct {
+		method  string
+		hasBody bool
+		want    string
+	}{
+		{"", false, "GET"},
+		{"", true, "POST"},
+		{"delete", false, "DELETE"},
+		{"PATCH", true, "PATCH"},
+	}
+	for _, tt := range tests {
+		if got := defaultMethod(tt.method, tt.hasBody); got != tt.want {
+			t.Errorf("defaultMethod(%q, %v) = %q, want %q", tt.method, tt.hasBody, got, tt.want)
+		}
+	}
+}

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -7,6 +7,7 @@ import (
 
 	"cloud.google.com/go/firestore"
 
+	"github.com/gugahoi/firestore/pkg/cmd/api"
 	"github.com/gugahoi/firestore/pkg/cmd/auth"
 	"github.com/gugahoi/firestore/pkg/cmd/browse"
 	"github.com/gugahoi/firestore/pkg/cmd/collection"
@@ -77,6 +78,7 @@ var host string
 func init() {
 	rootCmd.PersistentFlags().StringVarP(&projectId, "project", "p", "", "Google Cloud Project")
 	rootCmd.PersistentFlags().StringVar(&host, "host", "", "Firestore host (e.g., localhost:8080 for emulator)")
+	rootCmd.AddCommand(api.NewApiCmd())
 	rootCmd.AddCommand(auth.NewAuthCmd())
 	rootCmd.AddCommand(browse.NewBrowseCmd())
 	rootCmd.AddCommand(document.NewDocumentCmd())


### PR DESCRIPTION
## What

Adds `firestore api <path>` — a `gh api`-style escape hatch for hitting any Firestore **REST** endpoint with the project and credentials already configured. Covers interactions the CLI does not wrap yet (named databases, `:runQuery`, `:batchGet`, field masks, admin endpoints, ...) without needing a bespoke command for each.

## Behaviour

- **Path resolution:** relative paths (`users/u1`) expand under `projects/<project>/databases/(default)/documents/`; paths starting with `projects/` are sent verbatim (after `/v1/`) for admin/query endpoints.
- **Placeholders:** `{project}` → `--project`/`PROJECT_ID`, `{database}` → `(default)`.
- **Flags:** `-X/--method` (default GET, or POST when a body is given); `--input <file>` or `--input -` (STDIN), with automatic `application/json` content-type.
- **Auth:** Application Default Credentials (`firestore auth login`); uses the emulator with no real creds when `--host`/`FIRESTORE_EMULATOR_HOST` is set.
- **Output:** pretty-printed JSON (raw fallback); HTTP >= 400 returns a non-zero exit with the error body.
- Full behaviour documented in `firestore api --help`.

No new dependencies — `golang.org/x/oauth2/google` was already available.

## Testing

- `go build`, `go vet ./...`, `go test ./...` all green; unit tests cover path resolution (relative/verbatim/placeholders/leading-slash) and method defaulting.
- End-to-end against the Firestore emulator: create (POST via STDIN), get, `:runQuery` with placeholders, delete, and a 404 returning a non-zero exit with the error body — all verified.