### PR TITLE
feat(browse): edit hovered document from a collection column

### DIFF
--- a/pkg/cmd/browse/editor.go
+++ b/pkg/cmd/browse/editor.go
@@ -14,13 +14,13 @@ import (
 
 // editSession holds state for an ongoing edit session
 type editSession struct {
-	client     *firestore.Client
-	docPath    string
-	tempFile   string
-	editor     string
-	isCreate   bool   // true when creating a new document
-	colPath    string // collection path (for create mode)
-	colIndex   int    // column index to refresh after create
+	client   *firestore.Client
+	docPath  string
+	tempFile string
+	editor   string
+	isCreate bool   // true when creating a new document
+	colPath  string // collection path (for create mode)
+	colIndex int    // column index to refresh after create
 }
 
 // detectEditor finds the user's preferred editor
@@ -98,6 +98,16 @@ func startEditCmd(client *firestore.Client, docPath string, docData map[string]i
 		editor, err := detectEditor()
 		if err != nil {
 			return errorMsg{err: err}
+		}
+
+		// Hovered-document edit: data not loaded yet, fetch it.
+		if docData == nil {
+			ctx := context.Background()
+			snap, err := client.Doc(strings.TrimPrefix(docPath, "/")).Get(ctx)
+			if err != nil {
+				return errorMsg{err: fmt.Errorf("failed to load document: %w", err)}
+			}
+			docData = snap.Data()
 		}
 
 		logDebug("Starting edit for document: %s", docPath)

--- a/pkg/cmd/browse/update.go
+++ b/pkg/cmd/browse/update.go
@@ -660,13 +660,17 @@ func (m Model) handleKeyPress(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 
 		col := m.columns[m.activeColumn]
-		if !col.isDoc {
-			m.statusMsg = "Can only edit documents (not collections)"
+		if col.isDoc {
+			return m, startEditCmd(m.client, col.path, col.docData)
+		}
+
+		item := m.getSelectedItem()
+		if item == nil || !item.isDoc {
+			m.statusMsg = "Select a document to edit"
 			m.statusMsgTime = time.Now()
 			return m, clearStatusAfterDelay()
 		}
-
-		return m, startEditCmd(m.client, col.path, col.docData)
+		return m, startEditCmd(m.client, item.path, nil) // nil → fetch in cmd
 
 	case "r":
 		// Refresh current column


### PR DESCRIPTION
## Summary
- `e` now edits the highlighted document while hovering in a collection column, not just when inside a document column — matching the existing `d`/`R`/`c` handlers.
- `startEditCmd` fetches the document data when it isn't already loaded (the hovered-item case); the doc-column path is unchanged.
- Rejection message updated to "Select a document to edit" when the highlighted item is a sub-collection.

## Test plan
- `go build -o firestore .` passes
- `go test ./...` passes
- `make integration-test` passes
- [x] Manual smoke test in TUI: hover a doc in a collection → `e` opens editor; hover a sub-collection → status message; inside a doc column → still edits